### PR TITLE
- Added `AudioPreset` model and a persistent `Presets` collection to …

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -12,5 +12,16 @@ namespace SoundBar.Models
 
         // List of background app names that the user explicitly allows to be shown
         public System.Collections.Generic.List<string> AllowedBackgroundApps { get; set; } = new System.Collections.Generic.List<string>();
+
+        // Saved audio presets
+        public System.Collections.Generic.List<AudioPreset> Presets { get; set; } = new System.Collections.Generic.List<AudioPreset>();
+    }
+
+    public class AudioPreset
+    {
+        public string Name { get; set; } = string.Empty;
+        public float MasterVolume { get; set; }
+        // Key: Application executable name (e.g. "spotify.exe"), Value: Volume percentage 0-100 or float 0-1
+        public System.Collections.Generic.Dictionary<string, float> AppVolumes { get; set; } = new System.Collections.Generic.Dictionary<string, float>();
     }
 }

--- a/Models/AudioAppModel.cs
+++ b/Models/AudioAppModel.cs
@@ -44,9 +44,9 @@ namespace SoundBar.Models
                     OnPropertyChanged(nameof(VolumePercentage));
 
                     // Actually changes the volume
-                    if (_audioService != null)
+                    if (_audioService != null && !string.IsNullOrEmpty(Name))
                     {
-                        _audioService.SetVolume(ProcessId, _volume);
+                        _audioService.SetVolume(Name, _volume);
                     }
                 }
             }
@@ -56,9 +56,9 @@ namespace SoundBar.Models
         // Useful if the game destroyed its audio session and just recreated a new one
         public void PushVolumeToOS()
         {
-            if (_audioService != null)
+            if (_audioService != null && !string.IsNullOrEmpty(Name))
             {
-                _audioService.SetVolume(ProcessId, _volume);
+                _audioService.SetVolume(Name, _volume);
             }
         }
 
@@ -96,9 +96,9 @@ namespace SoundBar.Models
                     OnPropertyChanged();
 
                     // Actually mutes/unmutes
-                    if (_audioService != null)
+                    if (_audioService != null && !string.IsNullOrEmpty(Name))
                     {
-                        _audioService.SetMute(ProcessId, _isMuted);
+                        _audioService.SetMute(Name, _isMuted);
                     }
                 }
             }

--- a/Services/IAudioMixerService.cs
+++ b/Services/IAudioMixerService.cs
@@ -1,4 +1,4 @@
-﻿using SoundBar.Models;
+using SoundBar.Models;
 
 namespace SoundBar.Services
 {
@@ -7,11 +7,11 @@ namespace SoundBar.Services
         // Returns list of all apps currently making sound
         List<AudioAppModel> GetActiveAudioSessions();
 
-        // Update volume for specific app using PID
-        void SetVolume(int processID, float level);
+        // Update volume for specific app using Process Name
+        void SetVolume(string processName, float level);
 
         // Mutes or unmutes specific app
-        void SetMute(int processID, bool isMuted);
+        void SetMute(string processName, bool isMuted);
 
         // Master volume controls
         float GetMasterVolume();

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -9,11 +9,19 @@ namespace SoundBar.Services
     {
         private readonly string _filePath;
 
+        public AppSettings Settings { get; private set; }
+
         public SettingsService()
         {
             // Save 'config.json' in the same folder as the executable
             string folder = AppDomain.CurrentDomain.BaseDirectory;
             _filePath = Path.Combine(folder, "config.json");
+            Settings = Load();
+        }
+
+        public void SaveSettings()
+        {
+            Save(Settings);
         }
 
         public AppSettings Load()

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -39,7 +39,6 @@ namespace SoundBar.Services
                 {
                     LatestVersion = releaseInfo.TagName;
 
-                    // Temporary logic for testing: If versions are DIFFERENT, we consider it an update.
                     // Before actual release, change this to: if (IsNewerVersion(LatestVersion, CurrentVersion))
                     if (LatestVersion != CurrentVersion)
                     {

--- a/Services/WindowsAudioMixerService.cs
+++ b/Services/WindowsAudioMixerService.cs
@@ -13,8 +13,8 @@ namespace SoundBar.Services
         {
             var apps = new List<AudioAppModel>();
 
-            // Track which IDs we have processed to prevent duplicates
-            var addedProcessIds = new HashSet<int>();
+            // Track which NAMES we have processed to prevent duplicates
+            var addedProcessNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Get the default audio device
             using (var enumerator = new MMDeviceEnumerator())
@@ -38,11 +38,34 @@ namespace SoundBar.Services
                             // Ignore expired sessions, but allow Inactive sessions so users can adjust volume of paused/silent apps (matches Windows Volume Mixer)
                             if (sessionControl.SessionState == AudioSessionState.AudioSessionStateExpired) continue;
 
-                            // Identify if this is a background process
-                            bool isBackground = process.MainWindowHandle == IntPtr.Zero;
+                            string processName = process.ProcessName;
+                            if (string.IsNullOrEmpty(processName)) continue;
 
-                            // If we already have a slider for this App ID, skip it to prevent duplicates
-                            if (addedProcessIds.Contains(process.Id)) continue;
+                            // Identify if this is a background process
+                            // Check ALL processes with this name. If ANY have a main window, it's not a background app.
+                            // (E.g. Discord's audio engine is headless, but the main Discord.exe UI has a window)
+                            bool isBackground = true;
+                            try
+                            {
+                                string safeName = processName.Replace(".exe", "", StringComparison.OrdinalIgnoreCase);
+                                var procs = System.Diagnostics.Process.GetProcessesByName(safeName);
+                                foreach (var p in procs)
+                                {
+                                    if (p.MainWindowHandle != IntPtr.Zero)
+                                    {
+                                        isBackground = false;
+                                        break;
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                // Fallback if access is denied
+                                isBackground = process.MainWindowHandle == IntPtr.Zero;
+                            }
+
+                            // If we already have a slider for this App Name, skip it to prevent duplicates
+                            if (addedProcessNames.Contains(processName)) continue;
 
                             string? safeIconPath = null;
                             try
@@ -58,14 +81,14 @@ namespace SoundBar.Services
                             {
                                 ProcessId = process.Id,
                                 IsBackgroundApp = isBackground,
-                                Name = process.ProcessName,
+                                Name = processName,
                                 Volume = simpleVolume.MasterVolume,
                                 IsMuted = simpleVolume.IsMuted,
                                 IconPath = safeIconPath
                             };
 
                             apps.Add(newApp);
-                            addedProcessIds.Add(process.Id);
+                            addedProcessNames.Add(processName);
                         }
                     }
                 }
@@ -73,17 +96,17 @@ namespace SoundBar.Services
             return apps;
         }
 
-        public void SetVolume(int processId, float level)
+        public void SetVolume(string processName, float level)
         {
-            PerformActionOnSession(processId, (volumeControl) =>
+            PerformActionOnSession(processName, (volumeControl) =>
             {
                 volumeControl.MasterVolume = level;
             });
         }
 
-        public void SetMute(int processId, bool isMuted)
+        public void SetMute(string processName, bool isMuted)
         {
-            PerformActionOnSession(processId, (volumeControl) =>
+            PerformActionOnSession(processName, (volumeControl) =>
             {
                 volumeControl.IsMuted = isMuted;
             });
@@ -137,7 +160,7 @@ namespace SoundBar.Services
             });
         }
 
-        private void PerformActionOnSession(int targetProcessId, Action<SimpleAudioVolume> action)
+        private void PerformActionOnSession(string targetProcessName, Action<SimpleAudioVolume> action)
         {
             Task.Run(() =>
             {
@@ -153,11 +176,10 @@ namespace SoundBar.Services
                             using (var sessionControl = session.QueryInterface<AudioSessionControl2>())
                             using (var simpleVolume = session.QueryInterface<SimpleAudioVolume>())
                             {
-                                if (sessionControl.Process != null && sessionControl.Process.Id == targetProcessId)
+                                if (sessionControl.Process != null && string.Equals(sessionControl.Process.ProcessName, targetProcessName, StringComparison.OrdinalIgnoreCase))
                                 {
-                                    // If yes, execute
+                                    // Apply action to all matching sessions
                                     action(simpleVolume);
-                                    return; // Stop searching
                                 }
                             }
                         }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -26,8 +26,29 @@ namespace SoundBar.ViewModels
         // List of raw system background apps for the UI to display
         public ObservableCollection<string> SystemBackgroundApps { get; set; }
 
-        // Specia list, add/remove items here the UI auto updates itself
+        // Special list, add/remove items here the UI auto updates itself
         public ObservableCollection<AudioAppModel> Apps { get; set; }
+
+        // Saved presets
+        public ObservableCollection<AudioPreset> Presets { get; set; }
+
+        private AudioPreset? _selectedPreset;
+        public AudioPreset? SelectedPreset
+        {
+            get => _selectedPreset;
+            set
+            {
+                if (_selectedPreset != value)
+                {
+                    _selectedPreset = value;
+                    OnPropertyChanged();
+                    if (_selectedPreset != null)
+                    {
+                        ApplyPreset(_selectedPreset);
+                    }
+                }
+            }
+        }
 
         // Update properties
         private bool _updateAvailable;
@@ -124,17 +145,15 @@ namespace SoundBar.ViewModels
             _updateService = new UpdateService();
             _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-            // Setup data container
-            Apps = new ObservableCollection<AudioAppModel>();
-
             // Connect to audio service
             _audioService = new WindowsAudioMixerService();
 
-            // Load hidden apps from settings
-            var settings = _settingsService.Load();
-            HiddenApps = new ObservableCollection<string>(settings.HiddenApps ?? new List<string>());
-            AllowedBackgroundApps = new ObservableCollection<string>(settings.AllowedBackgroundApps ?? new List<string>());
+            // Setup data container
+            Apps = new ObservableCollection<AudioAppModel>();
+            HiddenApps = new ObservableCollection<string>(_settingsService.Settings.HiddenApps);
             SystemBackgroundApps = new ObservableCollection<string>();
+            AllowedBackgroundApps = new ObservableCollection<string>(_settingsService.Settings.AllowedBackgroundApps);
+            Presets = new ObservableCollection<AudioPreset>(_settingsService.Settings.Presets);
 
             // Initial load of master volume
             _masterVolume = _audioService.GetMasterVolume();
@@ -230,16 +249,17 @@ namespace SoundBar.ViewModels
             {
                 var existingApp = Apps[i];
 
-                // If existing app is not in the new list
-                if (!latestSessions.Any(x => x.ProcessId == existingApp.ProcessId))
+                // If existing app is not in the new list (match by Name since ProcessId might fluctuate for multi-process apps like Discord)
+                if (!latestSessions.Any(x => string.Equals(x.Name, existingApp.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     bool isProcessDead = true;
                     try
                     {
-                        var proc = System.Diagnostics.Process.GetProcessById(existingApp.ProcessId);
-                        if (proc != null && !proc.HasExited)
+                        // Check if any process with this name is still running
+                        string safeName = existingApp.Name?.Replace(".exe", "", StringComparison.OrdinalIgnoreCase) ?? "";
+                        var procs = System.Diagnostics.Process.GetProcessesByName(safeName);
+                        if (procs.Length > 0)
                         {
-                            // The game/app is still running, it just temporarily destroyed its audio session (e.g. tabbed out of a fullscreen game)
                             isProcessDead = false;
                         }
                     }
@@ -324,9 +344,10 @@ namespace SoundBar.ViewModels
             if (string.IsNullOrEmpty(appName) || HiddenApps.Contains(appName)) return;
 
             HiddenApps.Add(appName);
-            SaveHiddenApps();
+            _settingsService.Settings.HiddenApps = HiddenApps.ToList();
+            _settingsService.SaveSettings();
 
-            // Immediately remove it from the active UI list
+            // Check if it's currently in the Apps list and remove it
             var appToRemove = Apps.FirstOrDefault(a => a.Name == appName);
             if (appToRemove != null)
             {
@@ -334,36 +355,95 @@ namespace SoundBar.ViewModels
             }
         }
 
-        // Unhides an app so it can be seen again
+        // Unhides an app
         public void UnhideApp(string appName)
         {
-            if (string.IsNullOrEmpty(appName) || !HiddenApps.Contains(appName)) return;
-
-            HiddenApps.Remove(appName);
-            SaveHiddenApps();
-
-            // The background poller will automatically pick it back up on the next tick
+            if (HiddenApps.Contains(appName))
+            {
+                HiddenApps.Remove(appName);
+                _settingsService.Settings.HiddenApps = HiddenApps.ToList();
+                _settingsService.SaveSettings();
+            }
         }
 
-        // Saves the current HiddenApps list to settings
-        private void SaveHiddenApps()
-        {
-            var settings = _settingsService.Load();
-            settings.HiddenApps = HiddenApps.ToList();
-            _settingsService.Save(settings);
-        }
-
-        // Allows a background app to be shown
+        // Allows a system background app to be shown
         public void AllowBackgroundApp(string appName)
         {
             if (string.IsNullOrEmpty(appName) || AllowedBackgroundApps.Contains(appName)) return;
 
             AllowedBackgroundApps.Add(appName);
-            SystemBackgroundApps.Remove(appName);
+            _settingsService.Settings.AllowedBackgroundApps = AllowedBackgroundApps.ToList();
+            _settingsService.SaveSettings();
 
-            var settings = _settingsService.Load();
-            settings.AllowedBackgroundApps = AllowedBackgroundApps.ToList();
-            _settingsService.Save(settings);
+            if (SystemBackgroundApps.Contains(appName))
+            {
+                SystemBackgroundApps.Remove(appName);
+            }
+        }
+
+        // Presets Logic
+        public void SavePreset(string presetName)
+        {
+            if (string.IsNullOrWhiteSpace(presetName)) return;
+
+            var newPreset = new AudioPreset
+            {
+                Name = presetName,
+                MasterVolume = MasterVolumePercentage / 100f
+            };
+
+            foreach (var app in Apps)
+            {
+                if (!string.IsNullOrEmpty(app.Name))
+                {
+                    newPreset.AppVolumes[app.Name] = app.Volume;
+                }
+            }
+
+            // Remove if preset with same name exists
+            var existing = Presets.FirstOrDefault(p => p.Name == presetName);
+            if (existing != null)
+            {
+                Presets.Remove(existing);
+            }
+
+            Presets.Add(newPreset);
+            _settingsService.Settings.Presets = Presets.ToList();
+            _settingsService.SaveSettings();
+
+            SelectedPreset = newPreset;
+        }
+
+        public void ApplyPreset(AudioPreset preset)
+        {
+            if (preset == null) return;
+
+            // Apply Master Volume
+            MasterVolumePercentage = (int)Math.Round(preset.MasterVolume * 100);
+
+            // Apply App Volumes
+            foreach (var app in Apps)
+            {
+                if (!string.IsNullOrEmpty(app.Name) && preset.AppVolumes.ContainsKey(app.Name))
+                {
+                    app.Volume = preset.AppVolumes[app.Name];
+                    app.PushVolumeToOS(); // Force OS to sync immediately
+                }
+            }
+        }
+
+        public void DeletePreset(AudioPreset preset)
+        {
+            if (preset == null || !Presets.Contains(preset)) return;
+
+            Presets.Remove(preset);
+            _settingsService.Settings.Presets = Presets.ToList();
+            _settingsService.SaveSettings();
+
+            if (SelectedPreset == preset)
+            {
+                SelectedPreset = null;
+            }
         }
 
         // Standard for MVVM updates

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -84,6 +84,51 @@
                     </StackPanel>
                 </Button>
 
+                <Grid Margin="0,0,0,15">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <ComboBox Grid.Column="0"
+                              HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding Presets}"
+                              SelectedItem="{Binding SelectedPreset, Mode=TwoWay}"
+                              DisplayMemberPath="Name"
+                              PlaceholderText="Audio Presets..."
+                              Margin="0,0,5,0"
+                              Background="#333333"
+                              BorderThickness="1"
+                              BorderBrush="#555555"
+                              Foreground="#DDDDDD"/>
+
+                    <Button Grid.Column="1"
+                            Content="&#xE710;"
+                            FontFamily="Segoe Fluent Icons"
+                            Width="32" Height="32"
+                            Padding="0" MinWidth="0" MinHeight="0"
+                            Background="#333333"
+                            Foreground="#DDDDDD"
+                            BorderBrush="#555555"
+                            BorderThickness="1"
+                            Margin="0,0,5,0"
+                            ToolTipService.ToolTip="Save Current Volumes as Preset"
+                            Click="SavePresetButton_Click"/>
+
+                    <Button Grid.Column="2"
+                            Content="&#xE74D;"
+                            FontFamily="Segoe Fluent Icons"
+                            Width="32" Height="32"
+                            Padding="0" MinWidth="0" MinHeight="0"
+                            Background="#333333"
+                            Foreground="#E81123"
+                            BorderBrush="#555555"
+                            BorderThickness="1"
+                            ToolTipService.ToolTip="Delete Selected Preset"
+                            Click="DeletePresetButton_Click"/>
+                </Grid>
+
                 <TextBlock Text="Master Volume" 
                            Foreground="#DDDDDD" 
                            FontSize="14" 

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -188,6 +188,43 @@ namespace SoundBar.Views
             ViewModel.ApplyUpdate();
         }
 
+        private async void SavePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            var textBox = new TextBox { PlaceholderText = "e.g., Gaming Mode, Focus Mode", Margin = new Thickness(0, 10, 0, 0) };
+            
+            var dialog = new ContentDialog
+            {
+                Title = "Save New Audio Preset",
+                Content = new StackPanel 
+                { 
+                    Children = 
+                    { 
+                        new TextBlock { Text = "Enter a name for this preset to save your current active volumes:" },
+                        textBox
+                    }
+                },
+                PrimaryButtonText = "Save",
+                CloseButtonText = "Cancel",
+                DefaultButton = ContentDialogButton.Primary,
+                XamlRoot = this.Content.XamlRoot
+            };
+
+            var result = await dialog.ShowAsync();
+
+            if (result == ContentDialogResult.Primary && !string.IsNullOrWhiteSpace(textBox.Text))
+            {
+                ViewModel.SavePreset(textBox.Text);
+            }
+        }
+
+        private void DeletePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel.SelectedPreset != null)
+            {
+                ViewModel.DeletePreset(ViewModel.SelectedPreset);
+            }
+        }
+
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             SaveWindowSettings();


### PR DESCRIPTION
…`AppSettings` via `SettingsService`.

- Built the Audio Presets UI (ComboBox, Save Dialog, and Delete controls) on `MainWindow`.
- Implemented logic in `MainViewModel` to take snapshots of the `MasterVolume` and all active App volumes, and instantly apply them to running applications.
- Refactored `WindowsAudioMixerService` to intelligently group multi-process applications (like Discord/Chrome) by Executable Name rather than Process ID, completely eliminating duplicate UI sliders.
- Upgraded the Background Application detection engine to scan all related sub-processes for an active Window Handle, preventing headless audio engines from incorrectly hiding the entire app from the main view.