### PR TITLE
v1.4.0: Resizable window support and critical persistence fixes

### DIFF
--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -2,9 +2,11 @@ namespace SoundBar.Models
 {
     public class AppSettings
     {
-        // Default position if no config exists
+        // Default position and size if no config exists
         public double WindowTop { get; set; } = 100;
         public double WindowLeft { get; set; } = 100;
+        public int WindowWidth { get; set; } = 400;
+        public int WindowHeight { get; set; } = 500;
         public bool IsPinned { get; set; } = false;
 
         // List of app names that should be hidden from the main view

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -13,8 +13,15 @@ namespace SoundBar.Services
 
         public SettingsService()
         {
-            // Save 'config.json' in the same folder as the executable
-            string folder = AppDomain.CurrentDomain.BaseDirectory;
+            // Save 'config.json' in %APPDATA%\SoundBar
+            string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string folder = Path.Combine(appData, "SoundBar");
+            
+            if (!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
             _filePath = Path.Combine(folder, "config.json");
             Settings = Load();
         }

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -14,7 +14,7 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v1.3.6";
+        public const string CurrentVersion = "v1.4.0";
         
         private const string RepoUrl = "https://api.github.com/repos/levon2805/SoundBar/releases/latest";
         private static readonly HttpClient _httpClient = new HttpClient();

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -41,12 +41,12 @@ namespace SoundBar.Views
             WindowId wndId = Win32Interop.GetWindowIdFromWindow(hWnd);
             _appWindow = AppWindow.GetFromWindowId(wndId);
             
-            _appWindow.Resize(new SizeInt32(400, 500));
+            
 
             if (_appWindow.Presenter is OverlappedPresenter presenter)
             {
                 presenter.IsMaximizable = false;
-                presenter.IsResizable = false;
+                presenter.IsResizable = true;
                 presenter.SetBorderAndTitleBar(true, false);
             }
 
@@ -93,7 +93,11 @@ namespace SoundBar.Views
         {
             var settings = _settingsService.Load();
 
-            _appWindow.Move(new PointInt32((int)settings.WindowLeft, (int)settings.WindowTop));
+            _appWindow.MoveAndResize(new RectInt32(
+                (int)settings.WindowLeft, 
+                (int)settings.WindowTop, 
+                settings.WindowWidth, 
+                settings.WindowHeight));
             
             if (settings.IsPinned)
             {
@@ -107,16 +111,17 @@ namespace SoundBar.Views
         private void SaveWindowSettings()
         {
             var position = _appWindow.Position;
+            var size = _appWindow.Size;
             var isPinned = IsTopmost();
 
-            var settings = new AppSettings
-            {
-                WindowTop = position.Y,
-                WindowLeft = position.X,
-                IsPinned = isPinned
-            };
+            // Update the existing settings object so we don't erase HiddenApps/BackgroundApps/Presets
+            _settingsService.Settings.WindowTop = position.Y;
+            _settingsService.Settings.WindowLeft = position.X;
+            _settingsService.Settings.WindowWidth = size.Width;
+            _settingsService.Settings.WindowHeight = size.Height;
+            _settingsService.Settings.IsPinned = isPinned;
 
-            _settingsService.Save(settings);
+            _settingsService.SaveSettings();
         }
 
         // Updates the pin icon color based on state


### PR DESCRIPTION
- Feature: Main window is now fully resizable.
- Feature: Window width and height are now saved and restored across app restarts.
- Fix: Resolved a bug where Hidden Apps and Allowed Background Apps were being erased every time the app was closed. The settings file is now correctly updated instead of completely overwritten.
- Enhancement: Migrated config.json save location to %APPDATA%\SoundBar to prevent read/write permission errors and ensure settings survive future app updates.