### PR TITLE
feat: add native audio output switcher & resolve COM memory leaks

### DIFF
--- a/Models/AudioDeviceModel.cs
+++ b/Models/AudioDeviceModel.cs
@@ -1,0 +1,11 @@
+namespace SoundBar.Models
+{
+    public class AudioDeviceModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool IsDefault { get; set; }
+
+        public override string ToString() => Name;
+    }
+}

--- a/Services/AudioDeviceSwitcher.cs
+++ b/Services/AudioDeviceSwitcher.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SoundBar.Services
+{
+    // Windows 10/11 (newer)
+    [Guid("f8679f50-850a-41cf-9c72-430f290290c8")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IPolicyConfig
+    {
+        [PreserveSig] int GetMixFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr ppFormat);
+        [PreserveSig] int GetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr ppFormat);
+        [PreserveSig] int ResetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName);
+        [PreserveSig] int SetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pEndpointFormat, IntPtr mixFormat);
+        [PreserveSig] int GetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr pmftDefaultPeriod, out IntPtr pmftMinimumPeriod);
+        [PreserveSig] int SetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pmftPeriod);
+        [PreserveSig] int GetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr pMode);
+        [PreserveSig] int SetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr mode);
+        [PreserveSig] int GetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, out IntPtr pv);
+        [PreserveSig] int SetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+        [PreserveSig] int SetDefaultEndpoint([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int role);
+        [PreserveSig] int SetEndpointVisibility([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bVisible);
+    }
+
+    // Windows 11 (some builds) / Windows 10 (Vista compatible)
+    [Guid("568b9108-44bf-40b4-9006-86afe5b5a620")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IPolicyConfigVista
+    {
+        [PreserveSig] int GetMixFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr ppFormat);
+        [PreserveSig] int GetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr ppFormat);
+        // Note: No ResetDeviceFormat in this interface
+        [PreserveSig] int SetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pEndpointFormat, IntPtr mixFormat);
+        [PreserveSig] int GetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr pmftDefaultPeriod, out IntPtr pmftMinimumPeriod);
+        [PreserveSig] int SetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pmftPeriod);
+        [PreserveSig] int GetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr pMode);
+        [PreserveSig] int SetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr mode);
+        [PreserveSig] int GetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, out IntPtr pv);
+        [PreserveSig] int SetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+        [PreserveSig] int SetDefaultEndpoint([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int role);
+        [PreserveSig] int SetEndpointVisibility([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bVisible);
+    }
+
+    // Classic Windows 7/8
+    [Guid("f8679f50-850a-41ce-8224-cb8a37f5e3b6")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IPolicyConfigClassic
+    {
+        [PreserveSig] int GetMixFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr ppFormat);
+        [PreserveSig] int GetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr ppFormat);
+        [PreserveSig] int ResetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName);
+        [PreserveSig] int SetDeviceFormat([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pEndpointFormat, IntPtr mixFormat);
+        [PreserveSig] int GetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int bDefault, out IntPtr pmftDefaultPeriod, out IntPtr pmftMinimumPeriod);
+        [PreserveSig] int SetProcessingPeriod([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr pmftPeriod);
+        [PreserveSig] int GetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, out IntPtr pMode);
+        [PreserveSig] int SetShareMode([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, IntPtr mode);
+        [PreserveSig] int GetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, out IntPtr pv);
+        [PreserveSig] int SetPropertyValue([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bFxStore, IntPtr key, IntPtr pv);
+        [PreserveSig] int SetDefaultEndpoint([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, int role);
+        [PreserveSig] int SetEndpointVisibility([MarshalAs(UnmanagedType.LPWStr)] string pszDeviceName, bool bVisible);
+    }
+
+    [ComImport, Guid("870af99c-171d-4f9e-af0d-e63df40c2bc9")]
+    internal class PolicyConfigClient
+    {
+    }
+
+    public static class AudioDeviceSwitcher
+    {
+        public static void SetDefaultDevice(string deviceId)
+        {
+            var pcc = new PolicyConfigClient();
+            
+            // Try Windows 10/11 version
+            if (pcc is IPolicyConfig config)
+            {
+                config.SetDefaultEndpoint(deviceId, 0); // eConsole
+                config.SetDefaultEndpoint(deviceId, 1); // eMultimedia
+                config.SetDefaultEndpoint(deviceId, 2); // eCommunications
+                Marshal.ReleaseComObject(pcc);
+                return;
+            }
+
+            // Try alternate Windows 11/Vista version
+            if (pcc is IPolicyConfigVista configVista)
+            {
+                configVista.SetDefaultEndpoint(deviceId, 0);
+                configVista.SetDefaultEndpoint(deviceId, 1);
+                configVista.SetDefaultEndpoint(deviceId, 2);
+                Marshal.ReleaseComObject(pcc);
+                return;
+            }
+
+            // Try classic Windows 7/8 version
+            if (pcc is IPolicyConfigClassic configClassic)
+            {
+                configClassic.SetDefaultEndpoint(deviceId, 0);
+                configClassic.SetDefaultEndpoint(deviceId, 1);
+                configClassic.SetDefaultEndpoint(deviceId, 2);
+                Marshal.ReleaseComObject(pcc);
+                return;
+            }
+
+            // Release if no interface matched
+            Marshal.ReleaseComObject(pcc);
+        }
+    }
+}

--- a/Services/IAudioMixerService.cs
+++ b/Services/IAudioMixerService.cs
@@ -18,5 +18,9 @@ namespace SoundBar.Services
         void SetMasterVolume(float level);
         bool GetMasterMute();
         void SetMasterMute(bool isMuted);
+
+        // Audio Output Device controls
+        List<AudioDeviceModel> GetAudioDevices();
+        void SetDefaultAudioDevice(string deviceId);
     }
 }

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -14,7 +14,7 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v1.5.2";
+        public const string CurrentVersion = "v1.6.0";
         
         private const string RepoUrl = "https://api.github.com/repos/levon2805/SoundBar/releases/latest";
         private static readonly HttpClient _httpClient = new HttpClient();
@@ -41,8 +41,8 @@ namespace SoundBar.Services
 
                     if (LatestVersion != CurrentVersion)
                     {
-                        var asset = releaseInfo.Assets?.FirstOrDefault(a => a.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
-                        if (asset != null)
+                        var asset = releaseInfo.Assets?.FirstOrDefault(a => a.Name != null && a.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+                        if (asset != null && asset.BrowserDownloadUrl != null)
                         {
                             DownloadUrl = asset.BrowserDownloadUrl;
                             return true;

--- a/Services/WindowsAudioMixerService.cs
+++ b/Services/WindowsAudioMixerService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace SoundBar.Services
 {
-    internal class WindowsAudioMixerService : IAudioMixerService
+    internal class WindowsAudioMixerService : IAudioMixerService, IDisposable
     {
         // Cache of ProcessId -> App Info to prevent allocating heavy Process objects every tick
         private readonly Dictionary<int, (string DisplayName, string RawProcessName, bool IsBackground, string? IconPath)> _processCache = new();
@@ -235,6 +235,51 @@ namespace SoundBar.Services
                     volume.IsMuted = isMuted;
                 }
             });
+        }
+
+        // Output Device Implementation
+
+        public List<AudioDeviceModel> GetAudioDevices()
+        {
+            var result = new List<AudioDeviceModel>();
+
+            using (var enumerator = new MMDeviceEnumerator())
+            {
+                string defaultDeviceId = string.Empty;
+                using (var defaultDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia))
+                {
+                    if (defaultDevice != null)
+                    {
+                        defaultDeviceId = defaultDevice.DeviceID;
+                    }
+                }
+                
+                using (var devices = enumerator.EnumAudioEndpoints(DataFlow.Render, DeviceState.Active))
+                {
+                    foreach (var device in devices)
+                    {
+                        result.Add(new AudioDeviceModel
+                        {
+                            Id = device.DeviceID,
+                            Name = device.FriendlyName,
+                            IsDefault = device.DeviceID == defaultDeviceId
+                        });
+                        device.Dispose(); // Dispose each individual device after processing
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public void SetDefaultAudioDevice(string deviceId)
+        {
+            AudioDeviceSwitcher.SetDefaultDevice(deviceId);
+        }
+
+        public void Dispose()
+        {
+            // No longer need to dispose CoreAudioController
         }
 
         private void PerformActionOnSession(string targetProcessName, Action<SimpleAudioVolume> action)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -7,11 +7,12 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using SoundBar.Helpers;
 
 
 namespace SoundBar.ViewModels
 {
-    public class MainViewModel : INotifyPropertyChanged
+    public class MainViewModel : INotifyPropertyChanged, IDisposable
     {
         private readonly IAudioMixerService _audioService;
         private readonly SettingsService _settingsService;
@@ -30,7 +31,28 @@ namespace SoundBar.ViewModels
         public ObservableCollection<AudioAppModel> Apps { get; set; }
 
         // Saved presets
-        public ObservableCollection<AudioPreset> Presets { get; set; }
+        public ObservableCollection<AudioPreset> Presets { get; }
+        public ObservableCollection<AudioDeviceModel> AudioDevices { get; }
+
+        private AudioDeviceModel? _selectedAudioDevice;
+        public AudioDeviceModel? SelectedAudioDevice
+        {
+            get => _selectedAudioDevice;
+            set
+            {
+                if (_selectedAudioDevice != value)
+                {
+                    _selectedAudioDevice = value;
+                    OnPropertyChanged();
+
+                    if (_selectedAudioDevice != null && !_isUpdatingDeviceFromSystem)
+                    {
+                        _audioService.SetDefaultAudioDevice(_selectedAudioDevice.Id);
+                    }
+                }
+            }
+        }
+        private bool _isUpdatingDeviceFromSystem = false;
 
         private AudioPreset? _selectedPreset;
         public AudioPreset? SelectedPreset
@@ -171,6 +193,7 @@ namespace SoundBar.ViewModels
             SystemBackgroundApps = new ObservableCollection<string>();
             AllowedBackgroundApps = new ObservableCollection<string>(_settingsService.Settings.AllowedBackgroundApps);
             Presets = new ObservableCollection<AudioPreset>(_settingsService.Settings.Presets);
+            AudioDevices = new ObservableCollection<AudioDeviceModel>();
 
             // Initial load of master volume
             _masterVolume = _audioService.GetMasterVolume();
@@ -206,13 +229,18 @@ namespace SoundBar.ViewModels
 
 
 
+        private System.Threading.CancellationTokenSource? _pollingCts;
+
         public void StartPolling()
         {
+            _pollingCts = new System.Threading.CancellationTokenSource();
+            var token = _pollingCts.Token;
+
             // Create the thread
             var thread = new Thread(() =>
             {
                 // Loop forever to keep checking for changes
-                while (true)
+                while (!token.IsCancellationRequested)
                 {
                     try
                     {
@@ -221,6 +249,9 @@ namespace SoundBar.ViewModels
 
                         // Get System Volume
                         var systemVol = _audioService.GetMasterVolume();
+
+                        // Get Audio Devices
+                        var audioDevices = _audioService.GetAudioDevices();
 
                         // Update UI thread safely
                         _dispatcherQueue.TryEnqueue(() =>
@@ -238,6 +269,9 @@ namespace SoundBar.ViewModels
                                     OnPropertyChanged(nameof(MasterVolumePercentage));
                                 }
                             }
+
+                            // Sync Audio Devices
+                            UpdateAudioDevices(audioDevices);
                         });
                     }
                     catch (System.Exception)
@@ -245,8 +279,13 @@ namespace SoundBar.ViewModels
                         // Ignore errors for now
                     }
 
-                    // Poll every 1 second
-                    Thread.Sleep(1000);
+                    // Poll every 1 second but respond to cancellation quickly
+                    int slept = 0;
+                    while (slept < 1000 && !token.IsCancellationRequested)
+                    {
+                        Thread.Sleep(100);
+                        slept += 100;
+                    }
                 }
             });
 
@@ -523,6 +562,63 @@ namespace SoundBar.ViewModels
         protected void OnPropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        private void UpdateAudioDevices(List<AudioDeviceModel> latestDevices)
+        {
+            // Simple sync: just rebuild if counts differ or default changed, to avoid heavy UI churn.
+            // A more complex sync could match IDs.
+            bool needsRebuild = false;
+
+            if (AudioDevices.Count != latestDevices.Count)
+            {
+                needsRebuild = true;
+            }
+            else
+            {
+                for (int i = 0; i < latestDevices.Count; i++)
+                {
+                    if (AudioDevices[i].Id != latestDevices[i].Id || AudioDevices[i].IsDefault != latestDevices[i].IsDefault)
+                    {
+                        needsRebuild = true;
+                        break;
+                    }
+                }
+            }
+
+            if (needsRebuild)
+            {
+                _isUpdatingDeviceFromSystem = true;
+                AudioDevices.Clear();
+                AudioDeviceModel? newDefault = null;
+
+                foreach (var device in latestDevices)
+                {
+                    AudioDevices.Add(device);
+                    if (device.IsDefault)
+                    {
+                        newDefault = device;
+                    }
+                }
+
+                if (newDefault != null && (SelectedAudioDevice == null || SelectedAudioDevice.Id != newDefault.Id))
+                {
+                    SelectedAudioDevice = newDefault;
+                }
+                _isUpdatingDeviceFromSystem = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            _pollingCts?.Cancel();
+            _pollingCts?.Dispose();
+            _pollingCts = null;
+
+            if (_audioService is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -27,7 +27,7 @@
                            Foreground="White" 
                            VerticalAlignment="Center" 
                            Margin="10,0,0,0"
-                           FontSize="12"
+                           FontSize="16"
                            FontWeight="SemiBold"/>
 
                 <Button x:Name="SettingsButton"
@@ -105,6 +105,23 @@
                             <TextBlock Text="{x:Bind ViewModel.UpdateBannerText, Mode=OneWay}" VerticalAlignment="Center" FontWeight="SemiBold"/>
                         </StackPanel>
                     </Button>
+
+                    <TextBlock Text="Output Device" 
+                               Foreground="#DDDDDD" 
+                               FontSize="14" 
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,5"/>
+                    <ComboBox x:Name="DeviceComboBox"
+                              HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding AudioDevices}"
+                              SelectedItem="{Binding SelectedAudioDevice, Mode=TwoWay}"
+                              DisplayMemberPath="Name"
+                              PlaceholderText="Select Output Device..."
+                              Background="#333333"
+                              BorderThickness="1"
+                              BorderBrush="#555555"
+                              Foreground="#DDDDDD"
+                              Margin="0,0,0,15"/>
 
                     <TextBlock Text="Master Volume" 
                                Foreground="#DDDDDD" 
@@ -221,7 +238,7 @@
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,10,0">
                     <StackPanel Spacing="10">
                         <!-- Hidden Apps First -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" IsExpanded="True" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
                             <Expander.Header>
                                 <TextBlock Text="Hidden Apps" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -41,7 +41,8 @@ namespace SoundBar.Views
             WindowId wndId = Win32Interop.GetWindowIdFromWindow(hWnd);
             _appWindow = AppWindow.GetFromWindowId(wndId);
             
-            
+            this.Title = "SoundBar";
+            _appWindow.Title = "SoundBar";
 
             if (_appWindow.Presenter is OverlappedPresenter presenter)
             {
@@ -56,6 +57,8 @@ namespace SoundBar.Views
             TitleBarGrid.PointerMoved += TitleBarGrid_PointerMoved;
             TitleBarGrid.PointerReleased += TitleBarGrid_PointerReleased;
             TitleBarGrid.PointerCanceled += TitleBarGrid_PointerCanceled;
+
+            this.Closed += (s, e) => { ViewModel.Dispose(); };
 
             CreateDesktopShortcut();
         }


### PR DESCRIPTION
- Implemented native `IPolicyConfig` COM interop to allow instant switching of Windows default audio output devices directly from the UI.
- Removed third-party `AudioSwitcher` dependency to resolve fatal `InvalidCastException` COM apartment collisions.
- Re-architected `WindowsAudioMixerService` to execute device switching synchronously on the STA thread.
- Fixed a critical memory leak in `MainViewModel` by implementing a `CancellationTokenSource` to gracefully terminate the background polling loop on application exit.
- Refactored all low-level CoreAudio API calls to guarantee `Dispose()` is invoked on unmanaged memory pointers (`MMDevice`, `SessionManager`, `SimpleAudioVolume`).
- Updated UI: Changed window taskbar title to "SoundBar", increased application title font size, and collapsed the Hidden Apps expander by default.
- Fixed minor null reference warnings in `UpdateService.cs`.