### PR TITLE
fix: resolve background memory leaks and COM stability

### DIFF
--- a/Models/AudioAppModel.cs
+++ b/Models/AudioAppModel.cs
@@ -69,6 +69,7 @@ namespace SoundBar.Models
                     // Debounce: cancel any pending SetVolume call and schedule a new one
                     // This prevents spawning 30+ Task.Run calls per second when dragging a slider
                     _volumeDebounce?.Cancel();
+                    _volumeDebounce?.Dispose();
                     _volumeDebounce = new System.Threading.CancellationTokenSource();
                     var token = _volumeDebounce.Token;
                     var capturedVolume = _volume;

--- a/Services/AudioDeviceSwitcher.cs
+++ b/Services/AudioDeviceSwitcher.cs
@@ -69,40 +69,47 @@ namespace SoundBar.Services
     {
         public static void SetDefaultDevice(string deviceId)
         {
-            var pcc = new PolicyConfigClient();
-            
-            // Try Windows 10/11 version
-            if (pcc is IPolicyConfig config)
+            try
             {
-                config.SetDefaultEndpoint(deviceId, 0); // eConsole
-                config.SetDefaultEndpoint(deviceId, 1); // eMultimedia
-                config.SetDefaultEndpoint(deviceId, 2); // eCommunications
-                Marshal.ReleaseComObject(pcc);
-                return;
-            }
+                var pcc = new PolicyConfigClient();
+                
+                // Try Windows 10/11 version
+                if (pcc is IPolicyConfig config)
+                {
+                    config.SetDefaultEndpoint(deviceId, 0); // eConsole
+                    config.SetDefaultEndpoint(deviceId, 1); // eMultimedia
+                    config.SetDefaultEndpoint(deviceId, 2); // eCommunications
+                    Marshal.ReleaseComObject(pcc);
+                    return;
+                }
 
-            // Try alternate Windows 11/Vista version
-            if (pcc is IPolicyConfigVista configVista)
+                // Try alternate Windows 11/Vista version
+                if (pcc is IPolicyConfigVista configVista)
+                {
+                    configVista.SetDefaultEndpoint(deviceId, 0);
+                    configVista.SetDefaultEndpoint(deviceId, 1);
+                    configVista.SetDefaultEndpoint(deviceId, 2);
+                    Marshal.ReleaseComObject(pcc);
+                    return;
+                }
+
+                // Try classic Windows 7/8 version
+                if (pcc is IPolicyConfigClassic configClassic)
+                {
+                    configClassic.SetDefaultEndpoint(deviceId, 0);
+                    configClassic.SetDefaultEndpoint(deviceId, 1);
+                    configClassic.SetDefaultEndpoint(deviceId, 2);
+                    Marshal.ReleaseComObject(pcc);
+                    return;
+                }
+
+                // Release if no interface matched
+                Marshal.ReleaseComObject(pcc);
+            }
+            catch
             {
-                configVista.SetDefaultEndpoint(deviceId, 0);
-                configVista.SetDefaultEndpoint(deviceId, 1);
-                configVista.SetDefaultEndpoint(deviceId, 2);
-                Marshal.ReleaseComObject(pcc);
-                return;
+                // Silently fail if COM is unavailable on this system
             }
-
-            // Try classic Windows 7/8 version
-            if (pcc is IPolicyConfigClassic configClassic)
-            {
-                configClassic.SetDefaultEndpoint(deviceId, 0);
-                configClassic.SetDefaultEndpoint(deviceId, 1);
-                configClassic.SetDefaultEndpoint(deviceId, 2);
-                Marshal.ReleaseComObject(pcc);
-                return;
-            }
-
-            // Release if no interface matched
-            Marshal.ReleaseComObject(pcc);
         }
     }
 }

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -14,16 +14,17 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v1.6.0";
+        public const string CurrentVersion = "v1.6.1";
         
         private const string RepoUrl = "https://api.github.com/repos/levon2805/SoundBar/releases/latest";
-        private static readonly HttpClient _httpClient = new HttpClient();
+        private static readonly HttpClient _httpClient;
 
         public string LatestVersion { get; private set; } = string.Empty;
         public string DownloadUrl { get; private set; } = string.Empty;
 
-        public UpdateService()
+        static UpdateService()
         {
+            _httpClient = new HttpClient();
             // GitHub API requires a User-Agent header
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("SoundBar", "1.0"));
         }

--- a/SoundBar.csproj
+++ b/SoundBar.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageReference Include="CSCore" Version="1.2.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.12" />
   </ItemGroup>
 
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -144,6 +144,7 @@ namespace SoundBar.ViewModels
 
                     // Send command to Windows (DEBOUNCED to prevent COM/GC pressure when dragging)
                     _masterVolumeDebounce?.Cancel();
+                    _masterVolumeDebounce?.Dispose();
                     _masterVolumeDebounce = new System.Threading.CancellationTokenSource();
                     var token = _masterVolumeDebounce.Token;
                     var capturedVolume = _masterVolume;


### PR DESCRIPTION
- Fixed a memory leak in AudioAppModel and MainViewModel where CancellationTokenSource wait handles were being cancelled but not disposed during slider interactions.
- Moved UpdateService HttpClient instantiation to a static constructor to prevent duplicate User-Agent headers across instances.
- Wrapped AudioDeviceSwitcher COM initialisation in a try/catch block to prevent hard crashes on environments with missing or corrupted COM configurations.
- Downgraded System.Drawing.Common to v8.0.12 to align with the .NET 8 target framework and resolve MSBuild assembly version conflicts.