### PR TITLE
feat: add custom background image support with dynamic dimming

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -121,6 +121,21 @@ namespace SoundBar.ViewModels
         public Microsoft.UI.Xaml.Visibility UpdateBannerVisibility => UpdateAvailable ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
         public string UpdateBannerText => IsUpdating ? "Downloading Update..." : $"Update Available ({LatestVersion}) - Click to Install";
 
+        // Background Image Property
+        private Microsoft.UI.Xaml.Media.ImageSource? _backgroundImage;
+        public Microsoft.UI.Xaml.Media.ImageSource? BackgroundImage
+        {
+            get => _backgroundImage;
+            private set
+            {
+                if (_backgroundImage != value)
+                {
+                    _backgroundImage = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         // Timestamp for Master Volume
         private DateTime _lastMasterVolumeChange = DateTime.MinValue;
         private System.Threading.CancellationTokenSource? _masterVolumeDebounce;
@@ -202,6 +217,9 @@ namespace SoundBar.ViewModels
             // Start the monitoring loop
             StartPolling();
 
+            // Load Custom Background Image
+            LoadBackgroundImageAsync();
+
             // Check for updates
             CheckForUpdatesAsync();
         }
@@ -226,6 +244,93 @@ namespace SoundBar.ViewModels
             IsUpdating = true;
             await _updateService.DownloadAndApplyUpdateAsync();
             IsUpdating = false;
+        }
+
+        public async void LoadBackgroundImageAsync()
+        {
+            try
+            {
+                string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                string folder = System.IO.Path.Combine(appData, "SoundBar", "Backgrounds");
+
+                if (!System.IO.Directory.Exists(folder))
+                {
+                    System.IO.Directory.CreateDirectory(folder);
+                    _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+                    return; 
+                }
+
+                // Run disk I/O on a background thread
+                string? imagePath = await System.Threading.Tasks.Task.Run(() =>
+                {
+                    var files = System.IO.Directory.GetFiles(folder);
+                    return files.FirstOrDefault(f => f.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ||
+                                                     f.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) ||
+                                                     f.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase));
+                });
+
+                if (imagePath != null)
+                {
+                    _dispatcherQueue.TryEnqueue(async () =>
+                    {
+                        try
+                        {
+                            var bitmap = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage();
+                            
+                            // MEMORY OPTIMIZATION: Constrain the decoded image size.
+                            // A raw 4K wallpaper consumes ~33MB of RAM. Limiting it to 800px width 
+                            // keeps memory usage tiny while looking crystal clear on the widget.
+                            bitmap.DecodePixelWidth = 800;
+
+                            // Use FileShare.ReadWrite so we don't crash if the user is mid-copying a file
+                            using var stream = System.IO.File.Open(imagePath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite);
+                            using var randomAccessStream = stream.AsRandomAccessStream();
+                            await bitmap.SetSourceAsync(randomAccessStream);
+                            BackgroundImage = bitmap;
+                        }
+                        catch
+                        {
+                            // If the file is heavily locked or corrupted, silently ignore
+                            // rather than clearing their existing background.
+                        }
+                    });
+                }
+                else
+                {
+                    _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+                }
+            }
+            catch
+            {
+                _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+            }
+        }
+
+        public void OpenBackgroundFolder()
+        {
+            try
+            {
+                string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                string folder = System.IO.Path.Combine(appData, "SoundBar", "Backgrounds");
+
+                if (!System.IO.Directory.Exists(folder))
+                {
+                    System.IO.Directory.CreateDirectory(folder);
+                }
+
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                {
+                    FileName = folder,
+                    UseShellExecute = true,
+                    Verb = "open"
+                });
+            }
+            catch { }
+        }
+
+        public void ReloadBackground()
+        {
+            LoadBackgroundImageAsync();
         }
 
 

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -3,17 +3,23 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Border Background="#2D2D30" 
             BorderBrush="#444444" 
-            BorderThickness="1"
-            Padding="20">
+            BorderThickness="1">
 
         <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+            <!-- Background Image Layer -->
+            <Image Stretch="UniformToFill" Source="{x:Bind ViewModel.BackgroundImage, Mode=OneWay}" />
+            <!-- Dimming Overlay Layer -->
+            <Border Background="#D8202020" />
+
+            <!-- Application Content -->
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
             <!-- Title Bar -->
-            <Grid x:Name="TitleBarGrid" Grid.Row="0" Margin="-20,-20,-20,15" Padding="20,20,20,0" Background="Transparent" Canvas.ZIndex="10">
+            <Grid x:Name="TitleBarGrid" Grid.Row="0" Margin="0,0,0,15" Padding="20,20,20,0" Background="Transparent" Canvas.ZIndex="10">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
@@ -83,7 +89,7 @@
             </Grid>
 
             <!-- Main Content -->
-            <Grid x:Name="MainContentGrid" Grid.Row="1">
+            <Grid x:Name="MainContentGrid" Grid.Row="1" Margin="20,0,20,20">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -212,7 +218,7 @@
             </Grid>
 
             <!-- Settings Content -->
-            <Grid x:Name="SettingsContentGrid" Grid.Row="1" Visibility="Collapsed">
+            <Grid x:Name="SettingsContentGrid" Grid.Row="1" Visibility="Collapsed" Margin="20,0,20,20">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
@@ -237,7 +243,26 @@
 
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,10,0">
                     <StackPanel Spacing="10">
-                        <!-- Hidden Apps First -->
+                        <!-- Custom Background -->
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                            <Expander.Header>
+                                <TextBlock Text="Custom Background" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                            </Expander.Header>
+                            <StackPanel>
+                                <TextBlock Text="Place a .jpg or .png image in the backgrounds folder to personalize your SoundBar." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <Grid Margin="0,5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="10"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Button Grid.Column="0" Content="Open Folder" HorizontalAlignment="Stretch" Background="#333333" Foreground="White" BorderThickness="0" Click="OpenBackgroundFolder_Click"/>
+                                    <Button Grid.Column="2" Content="Reload" HorizontalAlignment="Stretch" Background="#333333" Foreground="White" BorderThickness="0" Click="ReloadBackground_Click"/>
+                                </Grid>
+                            </StackPanel>
+                        </Expander>
+
+                        <!-- Hidden Apps -->
                         <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
                             <Expander.Header>
                                 <TextBlock Text="Hidden Apps" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
@@ -288,6 +313,7 @@
                         </Expander>
                     </StackPanel>
                 </ScrollViewer>
+            </Grid>
             </Grid>
         </Grid>
     </Border>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -236,6 +236,16 @@ namespace SoundBar.Views
             SettingsButton.Visibility = Visibility.Visible;
         }
 
+        private void OpenBackgroundFolder_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.OpenBackgroundFolder();
+        }
+
+        private void ReloadBackground_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.ReloadBackground();
+        }
+
         private void UpdateBanner_Click(object sender, RoutedEventArgs e)
         {
             ViewModel.ApplyUpdate();


### PR DESCRIPTION
- Added dynamic background image loading from the `%APPDATA%\SoundBar\Backgrounds` directory.
- Refactored `MainWindow.xaml` to support an edge-to-edge `Image` background layered beneath the UI, covered by an 85% opacity dimming overlay to maintain text readability.
- Added a new "Custom Background" expander section to the Settings menu with shortcuts to instantly open the background directory and reload the image.
- Implemented background thread file reading using `FileShare.ReadWrite` to prevent IO collision exceptions.
- Hardcoded `DecodePixelWidth` to 800px on the `BitmapImage` to prevent memory bloat when loading 4K/8K images into the lightweight UI.