### PR TITLE
feat: Implement global media controls and taskbar icon for v2.1.0

### DIFF
--- a/src/SoundBar/Helpers/MediaHelper.cs
+++ b/src/SoundBar/Helpers/MediaHelper.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SoundBar.Helpers
+{
+    public static class MediaHelper
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+
+        private const int KEYEVENTF_EXTENDEDKEY = 0x0001;
+        private const int KEYEVENTF_KEYUP = 0x0002;
+
+        private const byte VK_MEDIA_NEXT_TRACK = 0xB0;
+        private const byte VK_MEDIA_PREV_TRACK = 0xB1;
+        private const byte VK_MEDIA_STOP = 0xB2;
+        private const byte VK_MEDIA_PLAY_PAUSE = 0xB3;
+        private const byte VK_VOLUME_MUTE = 0xAD;
+
+        public static void PlayPause()
+        {
+            SendMediaKey(VK_MEDIA_PLAY_PAUSE);
+        }
+
+        public static void NextTrack()
+        {
+            SendMediaKey(VK_MEDIA_NEXT_TRACK);
+        }
+
+        public static void PreviousTrack()
+        {
+            SendMediaKey(VK_MEDIA_PREV_TRACK);
+        }
+
+        public static void Mute()
+        {
+            SendMediaKey(VK_VOLUME_MUTE);
+        }
+
+        private static void SendMediaKey(byte key)
+        {
+            // Press the key down
+            keybd_event(key, 0, KEYEVENTF_EXTENDEDKEY, UIntPtr.Zero);
+            // Release the key
+            keybd_event(key, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, UIntPtr.Zero);
+        }
+    }
+}

--- a/src/SoundBar/Models/AppSettings.cs
+++ b/src/SoundBar/Models/AppSettings.cs
@@ -10,6 +10,7 @@ namespace SoundBar.Models
         public bool IsPinned { get; set; } = false;
         public bool IsDoNotDisturbEnabled { get; set; } = false;
         public bool IsLoudnessWarningEnabled { get; set; } = true;
+        public bool ShowMediaControls { get; set; } = true;
 
         // List of app names that should be hidden from the main view
         public System.Collections.Generic.List<string> HiddenApps { get; set; } = new System.Collections.Generic.List<string>();

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -14,7 +14,7 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v2.0.0";
+        public const string CurrentVersion = "v2.1.0";
         
         private const string RepoUrl = "https://api.github.com/repos/levon2805/SoundBar/releases/latest";
         private static HttpClient _httpClient;

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -214,6 +214,25 @@ namespace SoundBar.ViewModels
         private DateTime _lastMasterVolumeChange = DateTime.MinValue;
         private System.Threading.CancellationTokenSource? _masterVolumeDebounce;
 
+        private bool _showMediaControls;
+        public bool ShowMediaControls
+        {
+            get => _showMediaControls;
+            set
+            {
+                if (_showMediaControls != value)
+                {
+                    _showMediaControls = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(MediaControlsVisibility));
+                    _settingsService.Settings.ShowMediaControls = value;
+                    _settingsService.SaveSettings();
+                }
+            }
+        }
+
+        public Microsoft.UI.Xaml.Visibility MediaControlsVisibility => ShowMediaControls ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
+
         // Master Volume Property
         private float _masterVolume;
         public float MasterVolume
@@ -291,6 +310,7 @@ namespace SoundBar.ViewModels
             // Initial load of settings
             _isDoNotDisturbEnabled = _settingsService.Settings.IsDoNotDisturbEnabled;
             _isLoudnessWarningEnabled = _settingsService.Settings.IsLoudnessWarningEnabled;
+            _showMediaControls = _settingsService.Settings.ShowMediaControls;
             _audioService.SetSystemSoundsMute(_isDoNotDisturbEnabled);
 
             // Start the monitoring loop

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -110,6 +110,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 
                 <StackPanel Grid.Row="0">
@@ -246,6 +247,57 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </ScrollViewer>
+
+                <!-- Media Controls -->
+                <StackPanel Grid.Row="2" Margin="0,10,0,-10" Visibility="{x:Bind ViewModel.MediaControlsVisibility, Mode=OneWay}">
+                    <Border Height="1" Background="#555555" Margin="0,0,0,8"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="5">
+                        <Button Content="&#xE892;" 
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                                Background="Transparent" 
+                                Foreground="#DDDDDD" 
+                                BorderThickness="0" 
+                                FontSize="16"
+                                Width="36" Height="36"
+                                Padding="0" MinWidth="0" MinHeight="0"
+                                Click="MediaPrevious_Click" 
+                                ToolTipService.ToolTip="Previous Track" />
+
+                        <Button Background="Transparent" 
+                                BorderThickness="0" 
+                                Width="36" Height="36"
+                                Padding="0" MinWidth="0" MinHeight="0"
+                                Click="MediaPlayPause_Click" 
+                                ToolTipService.ToolTip="Play / Pause">
+                            <StackPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE768;" FontSize="14" Foreground="#DDDDDD"/>
+                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE769;" FontSize="14" Foreground="#DDDDDD"/>
+                            </StackPanel>
+                        </Button>
+
+                        <Button Content="&#xE893;" 
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                                Background="Transparent" 
+                                Foreground="#DDDDDD" 
+                                BorderThickness="0" 
+                                FontSize="16"
+                                Width="36" Height="36"
+                                Padding="0" MinWidth="0" MinHeight="0"
+                                Click="MediaNext_Click" 
+                                ToolTipService.ToolTip="Next Track" />
+
+                        <Button Content="&#xE74F;" 
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}" 
+                                Background="Transparent" 
+                                Foreground="#DDDDDD" 
+                                BorderThickness="0" 
+                                FontSize="16"
+                                Width="36" Height="36"
+                                Padding="0" MinWidth="0" MinHeight="0"
+                                Click="MediaMute_Click" 
+                                ToolTipService.ToolTip="Mute" />
+                    </StackPanel>
+                </StackPanel>
             </Grid>
 
             <!-- Settings Content -->
@@ -353,6 +405,19 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
+                            </StackPanel>
+                        </Expander>
+
+                        <!-- Media Controls Settings -->
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                            <Expander.Header>
+                                <TextBlock Text="Media Controls" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                            </Expander.Header>
+                            <StackPanel>
+                                <TextBlock Text="Shows global media controls at the bottom of the application (Previous, Play/Pause, Next, Mute)." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <ToggleSwitch Header="Show Media Controls" 
+                                              IsOn="{x:Bind ViewModel.ShowMediaControls, Mode=TwoWay}" 
+                                              Foreground="White"/>
                             </StackPanel>
                         </Expander>
                     </StackPanel>

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -44,6 +44,13 @@ namespace SoundBar.Views
             this.Title = "SoundBar";
             _appWindow.Title = "SoundBar";
 
+            // Set the icon for the taskbar and window
+            string iconPath = System.IO.Path.Combine(AppContext.BaseDirectory, "Assets", "SoundBar.ico");
+            if (System.IO.File.Exists(iconPath))
+            {
+                _appWindow.SetIcon(iconPath);
+            }
+
             if (_appWindow.Presenter is OverlappedPresenter presenter)
             {
                 presenter.IsMaximizable = false;
@@ -345,6 +352,26 @@ namespace SoundBar.Views
                 return presenter.IsAlwaysOnTop;
             }
             return false;
+        }
+
+        private void MediaPrevious_Click(object sender, RoutedEventArgs e)
+        {
+            MediaHelper.PreviousTrack();
+        }
+
+        private void MediaPlayPause_Click(object sender, RoutedEventArgs e)
+        {
+            MediaHelper.PlayPause();
+        }
+
+        private void MediaNext_Click(object sender, RoutedEventArgs e)
+        {
+            MediaHelper.NextTrack();
+        }
+
+        private void MediaMute_Click(object sender, RoutedEventArgs e)
+        {
+            MediaHelper.Mute();
         }
     }
 }


### PR DESCRIPTION
- Added a persistent global media control bar to the bottom of the main UI
- Implemented Previous, Play/Pause toggle, Next, and Mute using unmanaged `user32.dll` (`keybd_event`) for stateless execution
- Added a "Show Media Controls" toggle to settings (defaults to true) to allow hiding the bar
- Injected `SoundBar.ico` into the WinUI 3 AppWindow renderer to display the official logo on taskbar hover instead of the generic app icon
- Bumped application version to v2.1.0