### PR TITLE
v2.3.1

### DIFF
--- a/ReleaseTools/UpdateSigner/Program.cs
+++ b/ReleaseTools/UpdateSigner/Program.cs
@@ -51,11 +51,11 @@ namespace UpdateSigner
                 try
                 {
                     Console.WriteLine($"Signing {targetFile}...");
-                    byte[] fileBytes = File.ReadAllBytes(targetFile);
                     
                     // Hash and sign
                     using var sha256 = SHA256.Create();
-                    byte[] hash = sha256.ComputeHash(fileBytes);
+                    using var fs = new FileStream(targetFile, FileMode.Open, FileAccess.Read);
+                    byte[] hash = sha256.ComputeHash(fs);
                     
                     RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(rsa);
                     formatter.SetHashAlgorithm("SHA256");

--- a/ReleaseTools/UpdateSigner/Program.cs
+++ b/ReleaseTools/UpdateSigner/Program.cs
@@ -2,6 +2,11 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
+/*
+cd "C:\Personal Projects\SoundBar\ReleaseTools\UpdateSigner"
+dotnet run -- "C:\Users\UKGC\Desktop\SoundBar.zip"
+*/
+
 namespace UpdateSigner
 {
     class Program

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -15,7 +15,7 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v2.3.0";
+        public const string CurrentVersion = "v2.3.1";
         
         public const string PublicKeyBase64 = "PFJTQUtleVZhbHVlPjxNb2R1bHVzPnh6bTBBMENEb0xMdC96aDVSazhhb0R0Yk5zdUs0QWNQOEdaTUpSMHRadUhrKzN2M2pUZUhQYVRlbTQ3OFlrZk5nVzRBeTVDa05PNHhjSGVMM0tCSGk5dDlKbjIrdXEza2VaV2NsZFdPWCtESXJqbWUrbk1YSDZURDZzMDZ3VGpBM0RWWTYxOHRXNmQvdnNJTWc5emlEUUxKSFl5RGNPbXhkODVwRkJveTkyNE1YRFdvbFhpZUx6YmN6M2p0K1IweDcySzdmOGsrVHRoNzlpRzJOeVVHZGQ2Rng1Y2lzRzlUaGd3emhIczc2eVh2VGV5UHhEaElWVCt0eXZGSlBUaTEzaDhBRXhWdkhaVVJnVVU4RWxsZ2ZTWTRNNCs0NUNDYkRxc2dPVmR4RGNvTkNOa1YrOU80d2d0WnZJNkI3bzFnUzdtekdJN1JpWklvWkxIbnVtYnBlUT09PC9Nb2R1bHVzPjxFeHBvbmVudD5BUUFCPC9FeHBvbmVudD48L1JTQUtleVZhbHVlPg==";
 
@@ -89,7 +89,7 @@ namespace SoundBar.Services
             Directory.CreateDirectory(tempUpdateDir);
 
             // Download the ZIP
-            using var response = await _httpClient.GetAsync(DownloadUrl);
+            using var response = await _httpClient.GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
 
             using (var fs = new FileStream(zipPath, FileMode.Create))
@@ -98,7 +98,7 @@ namespace SoundBar.Services
             }
 
             // Download the SIG
-            using var sigResponse = await _httpClient.GetAsync(SignatureUrl);
+            using var sigResponse = await _httpClient.GetAsync(SignatureUrl, HttpCompletionOption.ResponseHeadersRead);
             sigResponse.EnsureSuccessStatusCode();
 
             using (var sigFs = new FileStream(sigPath, FileMode.Create))
@@ -113,11 +113,11 @@ namespace SoundBar.Services
                 using RSACryptoServiceProvider rsa = new RSACryptoServiceProvider();
                 rsa.FromXmlString(publicKeyXml);
 
-                byte[] zipBytes = File.ReadAllBytes(zipPath);
                 byte[] sigBytes = Convert.FromBase64String(File.ReadAllText(sigPath));
 
                 using var sha256 = SHA256.Create();
-                byte[] hash = sha256.ComputeHash(zipBytes);
+                using var zipFs = new FileStream(zipPath, FileMode.Open, FileAccess.Read);
+                byte[] hash = sha256.ComputeHash(zipFs);
 
                 RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(rsa);
                 deformatter.SetHashAlgorithm("SHA256");

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -267,16 +267,19 @@
                     </Grid.RowDefinitions>
 
                     <!-- Album Art -->
-                    <Border Grid.Row="0" CornerRadius="12" Margin="20" Background="#222222" HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <Image Source="{x:Bind ViewModel.CurrentSongThumbnail, Mode=OneWay}" Stretch="UniformToFill" Width="220" Height="220">
-                            <!-- Fallback icon if no thumbnail -->
-                            <ToolTipService.ToolTip>
-                                <ToolTip Content="No Artwork Available" />
-                            </ToolTipService.ToolTip>
-                        </Image>
-                    </Border>
-                    <!-- Fallback Icon behind image -->
-                    <TextBlock Grid.Row="0" FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE189;" FontSize="64" Foreground="#444444" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.FallbackIconVisibility, Mode=OneWay}" />
+                    <Viewbox Grid.Row="0" Margin="10" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="280">
+                        <Grid>
+                            <Border CornerRadius="12" Background="#222222" Width="250" Height="250">
+                                <Image Source="{x:Bind ViewModel.CurrentSongThumbnail, Mode=OneWay}" Stretch="UniformToFill">
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip Content="No Artwork Available" />
+                                    </ToolTipService.ToolTip>
+                                </Image>
+                            </Border>
+                            <!-- Fallback Icon behind image -->
+                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE189;" FontSize="64" Foreground="#444444" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.FallbackIconVisibility, Mode=OneWay}" />
+                        </Grid>
+                    </Viewbox>
 
                     <!-- Title -->
                     <TextBlock Grid.Row="1" Text="{x:Bind ViewModel.CurrentSongTitle, Mode=OneWay}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,5"/>


### PR DESCRIPTION
fix: resolve album art clipping and optimise updater memory (v2.3.1)

- Replaced rigid width/height constraints on Album Artwork with a responsive `Viewbox` to ensure perfect 1:1 aspect ratio scaling without clipping.
- Rewrote UpdateService cryptographic verification and ZIP downloads to use streaming IO (HttpCompletionOption.ResponseHeadersRead and FileStream).
- Eliminated large object heap (LOH) allocations by bypassing byte-array RAM buffering during SHA-256 signature validation.
- Applied identical streaming hash optimisations to the offline `UpdateSigner.exe` tool.
