### PR TITLE
feat: add "run at startup" setting integration (v2.3.2)

### DIFF
--- a/src/SoundBar/Models/AppSettings.cs
+++ b/src/SoundBar/Models/AppSettings.cs
@@ -11,6 +11,7 @@ namespace SoundBar.Models
         public bool IsDoNotDisturbEnabled { get; set; } = false;
         public bool IsLoudnessWarningEnabled { get; set; } = true;
         public bool ShowMediaControls { get; set; } = true;
+        public bool RunAtStartup { get; set; } = false;
 
         // List of app names that should be hidden from the main view
         public System.Collections.Generic.List<string> HiddenApps { get; set; } = new System.Collections.Generic.List<string>();

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -15,7 +15,7 @@ namespace SoundBar.Services
     public class UpdateService
     {
         // Change this every time releasing a new version
-        public const string CurrentVersion = "v2.3.1";
+        public const string CurrentVersion = "v2.3.2";
         
         public const string PublicKeyBase64 = "PFJTQUtleVZhbHVlPjxNb2R1bHVzPnh6bTBBMENEb0xMdC96aDVSazhhb0R0Yk5zdUs0QWNQOEdaTUpSMHRadUhrKzN2M2pUZUhQYVRlbTQ3OFlrZk5nVzRBeTVDa05PNHhjSGVMM0tCSGk5dDlKbjIrdXEza2VaV2NsZFdPWCtESXJqbWUrbk1YSDZURDZzMDZ3VGpBM0RWWTYxOHRXNmQvdnNJTWc5emlEUUxKSFl5RGNPbXhkODVwRkJveTkyNE1YRFdvbFhpZUx6YmN6M2p0K1IweDcySzdmOGsrVHRoNzlpRzJOeVVHZGQ2Rng1Y2lzRzlUaGd3emhIczc2eVh2VGV5UHhEaElWVCt0eXZGSlBUaTEzaDhBRXhWdkhaVVJnVVU4RWxsZ2ZTWTRNNCs0NUNDYkRxc2dPVmR4RGNvTkNOa1YrOU80d2d0WnZJNkI3bzFnUzdtekdJN1JpWklvWkxIbnVtYnBlUT09PC9Nb2R1bHVzPjxFeHBvbmVudD5BUUFCPC9FeHBvbmVudD48L1JTQUtleVZhbHVlPg==";
 

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -234,6 +234,48 @@ namespace SoundBar.ViewModels
 
         public Microsoft.UI.Xaml.Visibility MediaControlsVisibility => ShowMediaControls ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
 
+        // Run At Startup Property
+        private bool _runAtStartup;
+        public bool RunAtStartup
+        {
+            get => _runAtStartup;
+            set
+            {
+                if (_runAtStartup != value)
+                {
+                    _runAtStartup = value;
+                    OnPropertyChanged();
+                    _settingsService.Settings.RunAtStartup = value;
+                    _settingsService.SaveSettings();
+                    UpdateStartupRegistry(value);
+                }
+            }
+        }
+
+        private void UpdateStartupRegistry(bool enable)
+        {
+            try
+            {
+                using var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", true);
+                if (key != null)
+                {
+                    if (enable)
+                    {
+                        string exePath = System.Environment.ProcessPath ?? "";
+                        if (!string.IsNullOrEmpty(exePath))
+                        {
+                            key.SetValue("SoundBar", $"\"{exePath}\"");
+                        }
+                    }
+                    else
+                    {
+                        key.DeleteValue("SoundBar", false);
+                    }
+                }
+            }
+            catch { }
+        }
+
         // Master Volume Property
         private float _masterVolume;
         public float MasterVolume
@@ -321,6 +363,7 @@ namespace SoundBar.ViewModels
             _isDoNotDisturbEnabled = _settingsService.Settings.IsDoNotDisturbEnabled;
             _isLoudnessWarningEnabled = _settingsService.Settings.IsLoudnessWarningEnabled;
             _showMediaControls = _settingsService.Settings.ShowMediaControls;
+            _runAtStartup = _settingsService.Settings.RunAtStartup;
             _audioService.SetSystemSoundsMute(_isDoNotDisturbEnabled);
 
             // Start the monitoring loop

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -512,6 +512,19 @@
                                               Foreground="White"/>
                             </StackPanel>
                         </Expander>
+
+                        <!-- System Integration Settings -->
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                            <Expander.Header>
+                                <TextBlock Text="System Startup" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                            </Expander.Header>
+                            <StackPanel>
+                                <TextBlock Text="Automatically start SoundBar in the background when you log into Windows." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <ToggleSwitch Header="Run at Startup" 
+                                              IsOn="{x:Bind ViewModel.RunAtStartup, Mode=TwoWay}" 
+                                              Foreground="White"/>
+                            </StackPanel>
+                        </Expander>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>


### PR DESCRIPTION
- Added a new `RunAtStartup` property to AppSettings model to persist state.
- Implemented Windows Registry integration (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`) to enable seamless background startup.
- Designed a new "System Startup" UI Expander in the Settings Flyout with a ToggleSwitch.
- Startup executable path resolves dynamically via `System.Environment.ProcessPath`.