### PR TITLE
v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 ## Features
 * **Individual App Control:** Granular volume control over every active application on your PC.
+* **App Nicknaming:** Give your apps custom, friendly names just by clicking on them.
+* **Master Volume & Presets:** Control your entire system's audio, and save custom audio presets to instantly switch between different volume profiles (e.g., 'Gaming' vs 'Work').
+* **Music Player Mode:** A beautiful, full-sized music player view that pulls in album artwork and provides a scrubbable timeline for the currently playing song.
+* **Global Media Controls:** Convenient buttons at the bottom of the app to play, pause, skip, and mute system audio.
 * **Output Device Switching:** Seamlessly change your default Windows playback device directly from the overlay.
-* **Custom Backgrounds:** Drop any `.jpg` or `.png` into your backgrounds folder to deeply personalise the UI with an edge-to-edge dimmed wallpaper.
-* **Master Volume:** Dedicated slider for controlling your entire system's audio.
-* **Always-on-Top:** Pin the SoundBar overlay above all other windows.
+* **Light & Dark Themes:** Fully supports Windows 11 native light, dark, and system themes, letting you customise the look to your exact preference.
+* **Custom Backgrounds:** Drop any `.jpg` or `.png` into your backgrounds folder to deeply personalise the UI with an edge-to-edge frosted wallpaper.
+* **Smart Dimming:** Background dimming elegantly shifts to ensure text remains perfectly readable whether you use Light or Dark mode.
+* **Hearing Protection:** An optional excessive loudness warning helps you protect your ears if the volume stays high for too long.
+* **Always-on-Top & Start at Login:** Pin the SoundBar overlay above all other windows, and optionally have it run quietly in the background when your PC starts up.
+* **Do Not Disturb:** One-click toggle to mute all system notification sounds when you need peace and quiet.
 * **App Blacklist:** Hide specific applications from your mixer interface to reduce clutter.
-* **Background Audio Controls:** Automatically captures invisible background services (like System Sounds) and allows you to optionally expose and control them.
-* **Automated Updates:** The app will periodically check GitHub for updates and notify you when a new release is available with a 1-click install button.
-* **State Persistence:** SoundBar securely remembers your window position, pinned state, output device, and hidden apps across reboots.
-* **Modern WinUI 3 Design:** Built natively with the Windows App SDK for a sleek, dark-themed interface with custom window drag controls.
+* **Background Audio Controls:** Automatically captures invisible background services and allows you to optionally expose and control them.
+* **Automated Updates:** The app will periodically check GitHub for updates and notify you when a new release is available with a neat, 1-click update button.
+* **Modern WinUI 3 Design:** Built natively with the Windows App SDK for a sleek interface with smooth, responsive controls.
 
 ## Download & Install (For Users)
 The application is built as a completely self-contained, portable `.exe`. You do not need to install anything or download the Windows App SDK runtime!

--- a/src/SoundBar/App.xaml.cs
+++ b/src/SoundBar/App.xaml.cs
@@ -2,13 +2,25 @@ using Microsoft.UI.Xaml;
 
 namespace SoundBar
 {
+    /// <summary>
+    /// Provides application-specific behaviour to supplement the default Application class.
+    /// This is where the magic begins.
+    /// </summary>
     public partial class App : Application
     {
+        /// <summary>
+        /// Initializes the singleton application object.
+        /// </summary>
         public App()
         {
             this.InitializeComponent();
         }
 
+        /// <summary>
+        /// Invoked when the application is launched by the end user.
+        /// We just spin up the main window and bring it to the front.
+        /// </summary>
+        /// <param name="args">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             m_window = new SoundBar.Views.MainWindow();

--- a/src/SoundBar/Helpers/MediaHelper.cs
+++ b/src/SoundBar/Helpers/MediaHelper.cs
@@ -3,45 +3,68 @@ using System.Runtime.InteropServices;
 
 namespace SoundBar.Helpers
 {
+    /// <summary>
+    /// A sneaky little helper class that fakes pressing media keys on the keyboard.
+    /// It's a remarkably effective way to control background music players like Spotify.
+    /// </summary>
     public static class MediaHelper
     {
+        // We import the ancient user32.dll from Windows to send fake key presses.
         [DllImport("user32.dll", SetLastError = true)]
         private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
 
         private const int KEYEVENTF_EXTENDEDKEY = 0x0001;
         private const int KEYEVENTF_KEYUP = 0x0002;
 
+        // Magic numbers for media keys
         private const byte VK_MEDIA_NEXT_TRACK = 0xB0;
         private const byte VK_MEDIA_PREV_TRACK = 0xB1;
         private const byte VK_MEDIA_STOP = 0xB2;
         private const byte VK_MEDIA_PLAY_PAUSE = 0xB3;
         private const byte VK_VOLUME_MUTE = 0xAD;
 
+        /// <summary>
+        /// Pretends to press the Play/Pause button on the keyboard.
+        /// </summary>
         public static void PlayPause()
         {
             SendMediaKey(VK_MEDIA_PLAY_PAUSE);
         }
 
+        /// <summary>
+        /// Pretends to press the Next Track button.
+        /// </summary>
         public static void NextTrack()
         {
             SendMediaKey(VK_MEDIA_NEXT_TRACK);
         }
 
+        /// <summary>
+        /// Pretends to press the Previous Track button.
+        /// </summary>
         public static void PreviousTrack()
         {
             SendMediaKey(VK_MEDIA_PREV_TRACK);
         }
 
+        /// <summary>
+        /// Pretends to press the mute button on the keyboard.
+        /// </summary>
         public static void Mute()
         {
             SendMediaKey(VK_VOLUME_MUTE);
         }
 
+        /// <summary>
+        /// Does the actual dirty work of sending the key press and release to Windows.
+        /// </summary>
+        /// <param name="key">The byte code of the key to press.</param>
         private static void SendMediaKey(byte key)
         {
-            // Press the key down
+            // First we push the key down...
             keybd_event(key, 0, KEYEVENTF_EXTENDEDKEY, UIntPtr.Zero);
-            // Release the key
+            
+            // ...and then we lift our finger off it.
             keybd_event(key, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, UIntPtr.Zero);
         }
     }

--- a/src/SoundBar/Helpers/NativeMethods.cs
+++ b/src/SoundBar/Helpers/NativeMethods.cs
@@ -3,13 +3,25 @@ using System.Runtime.InteropServices;
 
 namespace SoundBar.Helpers
 {
+    /// <summary>
+    /// A collection of dark magic P/Invoke methods to talk directly to the Windows API.
+    /// Mostly used here so we can drag the borderless window around by its background.
+    /// </summary>
     public static class NativeMethods
     {
-        // Win32 Constants
+        /// <summary>
+        /// A Windows message telling the system that the left mouse button is pressed on a non-client area.
+        /// </summary>
         public const int WM_NCLBUTTONDOWN = 0xA1;
+
+        /// <summary>
+        /// A hit-test code telling Windows that the mouse is over the title bar (caption) of the window.
+        /// </summary>
         public const int HT_CAPTION = 0x2;
 
-        // Point structure for screen coordinates
+        /// <summary>
+        /// A simple coordinate structure used by the Windows API.
+        /// </summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct POINT
         {
@@ -17,16 +29,26 @@ namespace SoundBar.Helpers
             public int Y;
         }
 
-        // Retrieves the cursor's position, in screen coordinates
+        /// <summary>
+        /// Asks Windows exactly where the mouse cursor is sitting on the screen right now.
+        /// </summary>
+        /// <param name="lpPoint">The point structure to fill with the coordinates.</param>
+        /// <returns>True if it successfully grabbed the position.</returns>
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetCursorPos(out POINT lpPoint);
 
-        // Sends the specified message to a window
+        /// <summary>
+        /// Sends a message directly to a specific window's message queue.
+        /// We use this to trick Windows into thinking we clicked the title bar.
+        /// </summary>
         [DllImport("user32.dll")]
         public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
 
-        // Releases the mouse capture from a window
+        /// <summary>
+        /// Tells Windows to stop letting our app hog all the mouse input.
+        /// Crucial for letting the drag operation transition smoothly to the OS.
+        /// </summary>
         [DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
     }

--- a/src/SoundBar/Helpers/TimeSpanConverter.cs
+++ b/src/SoundBar/Helpers/TimeSpanConverter.cs
@@ -3,17 +3,30 @@ using Microsoft.UI.Xaml.Data;
 
 namespace SoundBar.Helpers
 {
+    /// <summary>
+    /// A neat little XAML converter that turns raw seconds into a lovely readable time format.
+    /// </summary>
     public class TimeSpanConverter : IValueConverter
     {
+        /// <summary>
+        /// Converts the raw double (seconds) coming from the slider into a nice string.
+        /// If it's a marathon podcast over an hour, it shows the hours too.
+        /// </summary>
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is double seconds)
             {
-                return TimeSpan.FromSeconds(seconds).ToString(@"m\:ss");
+                var ts = TimeSpan.FromSeconds(seconds);
+                return ts.TotalHours >= 1
+                    ? ts.ToString(@"h\:mm\:ss")
+                    : ts.ToString(@"m\:ss");
             }
             return value;
         }
 
+        /// <summary>
+        /// We only ever need to read the time, not write it back as a string, so we leave this blank.
+        /// </summary>
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
             throw new NotImplementedException();

--- a/src/SoundBar/Models/AppSettings.cs
+++ b/src/SoundBar/Models/AppSettings.cs
@@ -1,33 +1,97 @@
 namespace SoundBar.Models
 {
+    /// <summary>
+    /// Represents the core settings for the application. 
+    /// Everything here is saved so you don't lose your setup when you close the app.
+    /// </summary>
     public class AppSettings
     {
-        // Default position and size if no config exists
+        // We set some sensible defaults just in case there isn't a config file yet.
         public double WindowTop { get; set; } = 100;
         public double WindowLeft { get; set; } = 100;
         public int WindowWidth { get; set; } = 400;
         public int WindowHeight { get; set; } = 500;
+        
+        /// <summary>
+        /// Keeps the window pinned always on top of other windows.
+        /// </summary>
         public bool IsPinned { get; set; } = false;
+
+        /// <summary>
+        /// Mutes system sounds when enabled, brilliant for avoiding interruptions.
+        /// </summary>
         public bool IsDoNotDisturbEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Shows a warning if the master volume gets worryingly loud.
+        /// </summary>
         public bool IsLoudnessWarningEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Whether the media playback controls should be visible.
+        /// </summary>
         public bool ShowMediaControls { get; set; } = true;
+
+        /// <summary>
+        /// Whether the application should run automatically when Windows starts.
+        /// </summary>
         public bool RunAtStartup { get; set; } = false;
 
-        // List of app names that should be hidden from the main view
+        /// <summary>
+        /// A list of application names that the user prefers to keep hidden from the main view.
+        /// </summary>
         public System.Collections.Generic.List<string> HiddenApps { get; set; } = new System.Collections.Generic.List<string>();
 
-        // List of background app names that the user explicitly allows to be shown
+        /// <summary>
+        /// A list of background applications that the user explicitly wants to see in the mixer.
+        /// </summary>
         public System.Collections.Generic.List<string> AllowedBackgroundApps { get; set; } = new System.Collections.Generic.List<string>();
 
-        // Saved audio presets
+        /// <summary>
+        /// A lovely collection of audio presets you can quickly switch between.
+        /// </summary>
         public System.Collections.Generic.List<AudioPreset> Presets { get; set; } = new System.Collections.Generic.List<AudioPreset>();
+
+        /// <summary>
+        /// Any custom nicknames the user has given to their apps (e.g. renaming 'chrome' to 'Browser').
+        /// </summary>
+        public System.Collections.Generic.Dictionary<string, string> AppAliases { get; set; } = new System.Collections.Generic.Dictionary<string, string>();
+
+        /// <summary>
+        /// The visual theme of the application (Light, Dark, or System).
+        /// </summary>
+        public AppTheme Theme { get; set; } = AppTheme.System;
     }
 
+    /// <summary>
+    /// Represents the different visual themes available in the app.
+    /// </summary>
+    public enum AppTheme
+    {
+        System,
+        Light,
+        Dark
+    }
+
+    /// <summary>
+    /// Represents a saved configuration of volumes for your various apps.
+    /// </summary>
     public class AudioPreset
     {
+        /// <summary>
+        /// The name of the preset, chosen by the user.
+        /// </summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The overall system volume level to apply with this preset.
+        /// </summary>
         public float MasterVolume { get; set; }
-        // Key: Application executable name (e.g. "spotify.exe"), Value: Volume percentage 0-100 or float 0-1
+        
+        /// <summary>
+        /// Stores the volume level for individual applications.
+        /// The key is the raw executable name (like 'spotify.exe') and the value is the volume.
+        /// </summary>
         public System.Collections.Generic.Dictionary<string, float> AppVolumes { get; set; } = new System.Collections.Generic.Dictionary<string, float>();
     }
 }

--- a/src/SoundBar/Models/AudioAppModel.cs
+++ b/src/SoundBar/Models/AudioAppModel.cs
@@ -9,26 +9,62 @@ using SoundBar.Services;
 
 namespace SoundBar.Models
 {
-    // Interface that tells UI the value has changed and needs updating
-    public class AudioAppModel : INotifyPropertyChanged
+    /// <summary>
+    /// Represents a single audio application within the mixer.
+    /// This model handles its own volume debouncing to prevent hammering the Windows Audio API.
+    /// </summary>
+    public class AudioAppModel : INotifyPropertyChanged, IDisposable
     {
-        // Field definition
         private readonly IAudioMixerService _audioService;
 
-        // Process ID
+        /// <summary>
+        /// The OS-level process ID.
+        /// </summary>
         public int ProcessId { get; set; }
 
-        // The display name (cleaned up, e.g. "Stremio" instead of "stremio-shell-ng")
-        public string? Name { get; set; }
+        private string? _name;
+        /// <summary>
+        /// The name displayed in the UI. Users can edit this to give their apps custom nicknames.
+        /// </summary>
+        public string? Name
+        {
+            get => _name;
+            set
+            {
+                if (_name != value)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                    AliasChanged?.Invoke(RawProcessName ?? "", value ?? "");
+                }
+            }
+        }
 
-        // The raw OS process name (e.g. "stremio-shell-ng") — used for SetVolume/SetMute calls
+        /// <summary>
+        /// The original, untouched display name straight from Windows.
+        /// </summary>
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Fired whenever the user decides to give an application a cheeky new nickname.
+        /// </summary>
+        public Action<string, string>? AliasChanged { get; set; }
+
+        /// <summary>
+        /// The raw executable name (e.g. 'stremio-shell-ng.exe'). 
+        /// We use this to reliably match sessions even if they get renamed.
+        /// </summary>
         public string? RawProcessName { get; set; }
 
-        // Path to the .exe
+        /// <summary>
+        /// Where we can find the executable to grab a nice icon from.
+        /// </summary>
         public string? IconPath { get; set; }
 
-        // The loaded icon for the UI
         private Microsoft.UI.Xaml.Media.ImageSource? _appIcon;
+        /// <summary>
+        /// The visual icon loaded for the UI.
+        /// </summary>
         public Microsoft.UI.Xaml.Media.ImageSource? AppIcon
         {
             get => _appIcon;
@@ -42,44 +78,51 @@ namespace SoundBar.Models
             }
         }
 
-        // Track when we last touched this slider
+        /// <summary>
+        /// Tracks the last time the user fiddled with this app's volume slider.
+        /// Helps us know when to stop auto-syncing from Windows to avoid fighting the user.
+        /// </summary>
         public DateTime LastModified { get; private set; } = DateTime.MinValue;
 
-        // The Volume level (0.0 to 1.0)
         private float _volume;
         private System.Threading.CancellationTokenSource? _volumeDebounce;
 
+        /// <summary>
+        /// The current volume level, ranging from 0.0 to 1.0.
+        /// Modifying this will automatically debounce and tell Windows to change the volume.
+        /// </summary>
         public float Volume
         {
             get => _volume;
             set
             {
-                // Only notify if the value actually changes to save performance
+                // Only do the hard work if the volume actually changed.
                 if (_volume != value)
                 {
                     _volume = value;
 
-                    // Update timestamp so we know the user is interacting
+                    // Note down the time so we don't immediately overwrite the user's change.
                     LastModified = DateTime.Now;
 
-                    // This triggers the event that the UI listens for
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(VolumePercentage));
 
-                    // Debounce: cancel any pending SetVolume call and schedule a new one
-                    // This prevents spawning 30+ Task.Run calls per second when dragging a slider
+                    // Cancel any pending volume changes so we don't spam the OS while sliding.
                     _volumeDebounce?.Cancel();
-                    _volumeDebounce?.Dispose();
+                    
+                    // We let the GC tidy up the old token source once the task finishes.
                     _volumeDebounce = new System.Threading.CancellationTokenSource();
                     var token = _volumeDebounce.Token;
                     var capturedVolume = _volume;
                     string osName = RawProcessName ?? Name ?? "";
+                    
                     if (_audioService != null && !string.IsNullOrEmpty(osName))
                     {
                         _ = Task.Run(async () =>
                         {
                             try
                             {
+                                // Wait just a tiny bit to see if the user is still sliding.
                                 await Task.Delay(50, token);
                                 if (!token.IsCancellationRequested)
                                 {
@@ -94,9 +137,10 @@ namespace SoundBar.Models
         }
 
         /// <summary>
-        /// Updates the volume from an OS read without writing it back (avoids feedback loop).
-        /// Use this when syncing the slider to match what Windows reports.
+        /// Updates our volume state directly from Windows without triggering a write-back.
+        /// This stops an endless loop of us telling Windows the volume, and Windows telling us back.
         /// </summary>
+        /// <param name="volume">The volume level (0.0 to 1.0).</param>
         public void SyncVolumeFromOS(float volume)
         {
             if (_volume != volume)
@@ -108,8 +152,9 @@ namespace SoundBar.Models
         }
 
         /// <summary>
-        /// Updates the mute state from an OS read without writing it back (avoids feedback loop).
+        /// Quietly updates our mute state from Windows without causing a scene.
         /// </summary>
+        /// <param name="isMuted">Whether the app is currently muted.</param>
         public void SyncMuteFromOS(bool isMuted)
         {
             if (_isMuted != isMuted)
@@ -119,18 +164,22 @@ namespace SoundBar.Models
             }
         }
 
-        // Forces the current UI volume down to the Windows Audio Service
-        // Useful if the game destroyed its audio session and just recreated a new one
+        /// <summary>
+        /// Shoves our current volume down to the Windows Audio Service.
+        /// Brilliant for when an app completely destroys and recreates its audio session.
+        /// </summary>
         public void PushVolumeToOS()
         {
-            string osName = RawProcessName ?? Name ?? "";
+            string osName = RawProcessName ?? DisplayName ?? "";
             if (_audioService != null && !string.IsNullOrEmpty(osName))
             {
                 _audioService.SetVolume(osName, _volume);
             }
         }
 
-        // The volume represented as a percentage (0 to 100)
+        /// <summary>
+        /// A friendly percentage representation of the volume, perfect for UI bindings.
+        /// </summary>
         public int VolumePercentage
         {
             get => (int)Math.Round(_volume * 100);
@@ -140,15 +189,21 @@ namespace SoundBar.Models
             }
         }
 
-        // True if the app does not have a visible main window
+        /// <summary>
+        /// True if this seems to be a sneaky background process without a proper window.
+        /// </summary>
         public bool IsBackgroundApp { get; set; }
 
-        // True if the Windows Audio Session is currently active/inactive (not destroyed)
+        /// <summary>
+        /// Lets us know if the Windows Audio Session is still breathing.
+        /// </summary>
         public bool IsSessionAlive { get; set; } = true;
 
-        // Whether the app is muted
         private bool _isMuted;
 
+        /// <summary>
+        /// Mutes or unmutes the application, instantly telling Windows about the change.
+        /// </summary>
         public bool IsMuted
         {
             get => _isMuted;
@@ -157,14 +212,12 @@ namespace SoundBar.Models
                 if (_isMuted != value)
                 {
                     _isMuted = value;
-
-                    // Update timestamp here too
                     LastModified = DateTime.Now;
 
                     OnPropertyChanged();
 
-                    // Actually mutes/unmutes (use RawProcessName for OS matching)
-                    string osName = RawProcessName ?? Name ?? "";
+                    // Actually tell Windows to shut it up (or let it sing).
+                    string osName = RawProcessName ?? DisplayName ?? "";
                     if (_audioService != null && !string.IsNullOrEmpty(osName))
                     {
                         _audioService.SetMute(osName, _isMuted);
@@ -173,19 +226,26 @@ namespace SoundBar.Models
             }
         }
 
-        // Consturctor requiring the service to be passed in
+        /// <summary>
+        /// Creates a new instance of our audio app model.
+        /// </summary>
+        /// <param name="audioService">The service we use to boss around the Windows audio.</param>
         public AudioAppModel(IAudioMixerService audioService)
         {
             _audioService = audioService;
         }
 
+        /// <summary>
+        /// Attempts to extract a lovely icon from the application's executable.
+        /// We do the heavy lifting in the background to keep the UI smooth.
+        /// </summary>
         public async Task LoadIconAsync()
         {
             if (string.IsNullOrEmpty(IconPath) || AppIcon != null) return;
 
             try
             {
-                // Run disk I/O and extraction on a background thread
+                // Pop onto a background thread for disk reads.
                 byte[]? iconBytes = await Task.Run(() =>
                 {
                     try
@@ -201,19 +261,17 @@ namespace SoundBar.Models
                     }
                     catch
                     {
-                        // Ignore extraction errors
+                        // Some apps are notoriously stubborn about their icons. We'll just ignore them.
                     }
                     return null;
                 });
 
                 if (iconBytes != null)
                 {
-                    // Must initialise BitmapImage on the UI thread
+                    // Hop back to the UI thread to construct the actual image.
                     var dispatcher = DispatcherQueue.GetForCurrentThread();
                     if (dispatcher != null)
                     {
-                        // Since LoadIconAsync is already called from the UI thread (via UpdateCollection),
-                        // we can just directly await the stream load. But just to be safe, we ensure it's on UI.
                         using var ms = new MemoryStream(iconBytes);
                         using var ras = ms.AsRandomAccessStream();
                         var bitmap = new BitmapImage();
@@ -224,11 +282,19 @@ namespace SoundBar.Models
             }
             catch
             {
-                // Silently fail if icon extraction is denied
+                // Access denied or something similar. No big deal.
             }
         }
 
-        // Code required by INotifyPropertyChanged
+        /// <summary>
+        /// Cleans up any pending volume tasks when this model is tossed away.
+        /// </summary>
+        public void Dispose()
+        {
+            _volumeDebounce?.Cancel();
+            _volumeDebounce = null;
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         protected void OnPropertyChanged([CallerMemberName] string? name = null)

--- a/src/SoundBar/Models/AudioDeviceModel.cs
+++ b/src/SoundBar/Models/AudioDeviceModel.cs
@@ -1,9 +1,24 @@
 namespace SoundBar.Models
 {
+    /// <summary>
+    /// A simple model to hold the details of an audio output device.
+    /// Handy for showing the user what they're listening through.
+    /// </summary>
     public class AudioDeviceModel
     {
+        /// <summary>
+        /// The unique system identifier for this specific device.
+        /// </summary>
         public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The friendly, human-readable name of the device (e.g., 'Headphones (Realtek)').
+        /// </summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Indicates if this is the device Windows is currently using by default.
+        /// </summary>
         public bool IsDefault { get; set; }
 
         public override string ToString() => Name;

--- a/src/SoundBar/Models/AudioSessionData.cs
+++ b/src/SoundBar/Models/AudioSessionData.cs
@@ -1,18 +1,44 @@
 namespace SoundBar.Models
 {
     /// <summary>
-    /// Lightweight data-only snapshot of an audio session.
-    /// Used by the polling loop to carry volume/mute info without triggering
-    /// any OS side effects (unlike AudioAppModel whose property setters call SetVolume/SetMute).
+    /// A lightweight snapshot of an active audio session from the OS.
+    /// This is used to pass data around without holding onto heavy COM objects.
     /// </summary>
     public readonly struct AudioSessionData
     {
+        /// <summary>
+        /// The process ID associated with this audio session.
+        /// </summary>
         public int ProcessId { get; init; }
+
+        /// <summary>
+        /// The user-friendly name we'll show in the UI, usually cleaned up from the raw name.
+        /// </summary>
         public string DisplayName { get; init; }
+
+        /// <summary>
+        /// The actual executable name (e.g., 'spotify.exe'). Essential for matching sessions.
+        /// </summary>
         public string RawProcessName { get; init; }
+
+        /// <summary>
+        /// True if we suspect this app is running invisibly in the background without a main window.
+        /// </summary>
         public bool IsBackgroundApp { get; init; }
+
+        /// <summary>
+        /// The current volume level of the session, from 0.0 to 1.0.
+        /// </summary>
         public float Volume { get; init; }
+
+        /// <summary>
+        /// Indicates if the user has muted this specific session.
+        /// </summary>
         public bool IsMuted { get; init; }
+
+        /// <summary>
+        /// Where we can find the executable to extract a nice icon from.
+        /// </summary>
         public string? IconPath { get; init; }
     }
 }

--- a/src/SoundBar/Services/AudioDeviceSwitcher.cs
+++ b/src/SoundBar/Services/AudioDeviceSwitcher.cs
@@ -65,8 +65,17 @@ namespace SoundBar.Services
     {
     }
 
+    /// <summary>
+    /// A sneaky little helper class that talks directly to undocumented Windows COM APIs 
+    /// to switch the default audio output device. It tries a few different versions of the API 
+    /// to make sure it works across Windows 7, 10, and 11.
+    /// </summary>
     public static class AudioDeviceSwitcher
     {
+        /// <summary>
+        /// Tells Windows to instantly switch all its audio over to the specified device.
+        /// </summary>
+        /// <param name="deviceId">The unique ID of the device you want to switch to.</param>
         public static void SetDefaultDevice(string deviceId)
         {
             try

--- a/src/SoundBar/Services/IAudioMixerService.cs
+++ b/src/SoundBar/Services/IAudioMixerService.cs
@@ -2,29 +2,72 @@ using SoundBar.Models;
 
 namespace SoundBar.Services
 {
+    /// <summary>
+    /// The grand contract for anything that wants to boss around the system audio.
+    /// Implement this to control volumes, mutes, and devices.
+    /// </summary>
     public interface IAudioMixerService
     {
-        // Returns lightweight snapshots of all active audio sessions (no side effects)
+        /// <summary>
+        /// Grabs a quick, lightweight snapshot of all the applications currently making a racket.
+        /// Does not cause any side effects or alter volumes.
+        /// </summary>
         List<AudioSessionData> GetActiveAudioSessions();
 
-        // Update volume for specific app using Process Name
+        /// <summary>
+        /// Shoves the volume of a specific application up or down.
+        /// </summary>
+        /// <param name="processName">The raw executable name (like 'spotify.exe').</param>
+        /// <param name="level">The new volume level, from 0.0 to 1.0.</param>
         void SetVolume(string processName, float level);
 
-        // Mutes or unmutes specific app
+        /// <summary>
+        /// Instantly gags (or ungags) a specific application.
+        /// </summary>
+        /// <param name="processName">The raw executable name.</param>
+        /// <param name="isMuted">True to mute, false to let the music play.</param>
         void SetMute(string processName, bool isMuted);
 
-        // Master volume controls
+        /// <summary>
+        /// Fetches the overall master volume for the entire computer.
+        /// </summary>
         float GetMasterVolume();
+
+        /// <summary>
+        /// Sets the master volume for the entire system. Don't blow the speakers!
+        /// </summary>
+        /// <param name="level">The new volume level, from 0.0 to 1.0.</param>
         void SetMasterVolume(float level);
+
+        /// <summary>
+        /// Checks if the entire system is currently muted.
+        /// </summary>
         bool GetMasterMute();
+
+        /// <summary>
+        /// Mutes or unmutes the entire system in one go.
+        /// </summary>
         void SetMasterMute(bool isMuted);
 
-        // System Sounds Methods
+        /// <summary>
+        /// Checks if those pesky Windows system sounds (like error dings) are muted.
+        /// </summary>
         bool GetSystemSoundsMute();
+
+        /// <summary>
+        /// Silences (or enables) system sounds. A blessing for deep work.
+        /// </summary>
         void SetSystemSoundsMute(bool isMuted);
 
-        // Output Device Methods
+        /// <summary>
+        /// Asks Windows for a list of all the speakers and headphones plugged in right now.
+        /// </summary>
         List<AudioDeviceModel> GetAudioDevices();
+
+        /// <summary>
+        /// Tells Windows to switch all audio over to a different playback device.
+        /// </summary>
+        /// <param name="deviceId">The unique system identifier for the device.</param>
         void SetDefaultAudioDevice(string deviceId);
     }
 }

--- a/src/SoundBar/Services/MediaInfoService.cs
+++ b/src/SoundBar/Services/MediaInfoService.cs
@@ -19,7 +19,7 @@ namespace SoundBar.Services
         public bool IsPlaying { get; set; }
     }
 
-    public class MediaInfoService
+    public class MediaInfoService : IDisposable
     {
         private GlobalSystemMediaTransportControlsSessionManager? _sessionManager;
         private GlobalSystemMediaTransportControlsSession? _currentSession;
@@ -150,6 +150,23 @@ namespace SoundBar.Services
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Failed to get media properties: {ex.Message}");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_currentSession != null)
+            {
+                _currentSession.MediaPropertiesChanged -= CurrentSession_MediaPropertiesChanged;
+                _currentSession.TimelinePropertiesChanged -= CurrentSession_TimelinePropertiesChanged;
+                _currentSession.PlaybackInfoChanged -= CurrentSession_PlaybackInfoChanged;
+                _currentSession = null;
+            }
+
+            if (_sessionManager != null)
+            {
+                _sessionManager.CurrentSessionChanged -= SessionManager_CurrentSessionChanged;
+                _sessionManager = null;
             }
         }
     }

--- a/src/SoundBar/Services/SettingsService.cs
+++ b/src/SoundBar/Services/SettingsService.cs
@@ -5,15 +5,26 @@ using System.Text.Json;
 
 namespace SoundBar.Services
 {
+    /// <summary>
+    /// Handles all the reading and writing of our config file.
+    /// Ensures your precious settings are safe and sound between sessions.
+    /// </summary>
     public class SettingsService
     {
         private readonly string _filePath;
+        private readonly object _fileLock = new object();
 
+        /// <summary>
+        /// The currently loaded settings, ready to be used.
+        /// </summary>
         public AppSettings Settings { get; private set; }
 
+        /// <summary>
+        /// Sets up the service and figures out where to stick the config file.
+        /// </summary>
         public SettingsService()
         {
-            // Save 'config.json' in %APPDATA%\SoundBar
+            // We pop the config.json neatly into the user's AppData roaming folder.
             string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string folder = Path.Combine(appData, "SoundBar");
             
@@ -26,46 +37,65 @@ namespace SoundBar.Services
             Settings = Load();
         }
 
+        /// <summary>
+        /// Internal constructor used exclusively for testing so we don't clobber real settings.
+        /// </summary>
         internal SettingsService(string customFilePath)
         {
             _filePath = customFilePath;
             Settings = Load();
         }
 
+        /// <summary>
+        /// A handy wrapper to save the current settings back to disk.
+        /// </summary>
         public void SaveSettings()
         {
             Save(Settings);
         }
 
+        /// <summary>
+        /// Reads the config file from disk. If things go pear-shaped, we just return the defaults.
+        /// </summary>
         public AppSettings Load()
         {
-            if (!File.Exists(_filePath))
-                return new AppSettings();
+            lock (_fileLock)
+            {
+                if (!File.Exists(_filePath))
+                    return new AppSettings();
 
-            try
-            {
-                string json = File.ReadAllText(_filePath);
-                return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
-            }
-            catch
-            {
-                // If file is corrupt, return defaults
-                return new AppSettings();
+                try
+                {
+                    string json = File.ReadAllText(_filePath);
+                    return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+                }
+                catch
+                {
+                    // Oh dear, the file is corrupt. Let's just return a fresh slate rather than crashing.
+                    return new AppSettings();
+                }
             }
         }
 
+        /// <summary>
+        /// Writes the settings to disk, nicely formatted so you can peek at it in Notepad.
+        /// </summary>
         public void Save(AppSettings settings)
         {
-            try
+            lock (_fileLock)
             {
-                // Format the JSON so it's readable if you open the file manually
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                string json = JsonSerializer.Serialize(settings, options);
-                File.WriteAllText(_filePath, json);
-            }
-            catch
-            {
-                // Ignore save errors
+                try
+                {
+                    // WriteIndented makes the JSON much nicer for humans to read.
+                    var options = new JsonSerializerOptions { WriteIndented = true };
+                    string json = JsonSerializer.Serialize(settings, options);
+                    File.WriteAllText(_filePath, json);
+                }
+                catch
+                {
+                    // We just ignore save errors to prevent interrupting the user.
+                    // It's not ideal, but better than a hard crash.
+                }
             }
         }
     }

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -12,33 +12,60 @@ using System.Security.Cryptography;
 
 namespace SoundBar.Services
 {
+    /// <summary>
+    /// Handles everything related to keeping SoundBar up to date.
+    /// It sneaks a peek at GitHub to see if there's a shiny new version, downloads it, verifies it, and applies it.
+    /// </summary>
     public class UpdateService
     {
-        // Change this every time releasing a new version
-        public const string CurrentVersion = "v2.3.2";
+        /// <summary>
+        /// The version of the app currently running. Remember to bump this before every release!
+        /// </summary>
+        public const string CurrentVersion = "v2.4.0";
         
+        /// <summary>
+        /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.
+        /// </summary>
         public const string PublicKeyBase64 = "PFJTQUtleVZhbHVlPjxNb2R1bHVzPnh6bTBBMENEb0xMdC96aDVSazhhb0R0Yk5zdUs0QWNQOEdaTUpSMHRadUhrKzN2M2pUZUhQYVRlbTQ3OFlrZk5nVzRBeTVDa05PNHhjSGVMM0tCSGk5dDlKbjIrdXEza2VaV2NsZFdPWCtESXJqbWUrbk1YSDZURDZzMDZ3VGpBM0RWWTYxOHRXNmQvdnNJTWc5emlEUUxKSFl5RGNPbXhkODVwRkJveTkyNE1YRFdvbFhpZUx6YmN6M2p0K1IweDcySzdmOGsrVHRoNzlpRzJOeVVHZGQ2Rng1Y2lzRzlUaGd3emhIczc2eVh2VGV5UHhEaElWVCt0eXZGSlBUaTEzaDhBRXhWdkhaVVJnVVU4RWxsZ2ZTWTRNNCs0NUNDYkRxc2dPVmR4RGNvTkNOa1YrOU80d2d0WnZJNkI3bzFnUzdtekdJN1JpWklvWkxIbnVtYnBlUT09PC9Nb2R1bHVzPjxFeHBvbmVudD5BUUFCPC9FeHBvbmVudD48L1JTQUtleVZhbHVlPg==";
 
         private const string RepoUrl = "https://api.github.com/repos/levon2805/SoundBar/releases/latest";
         private static HttpClient _httpClient;
 
+        /// <summary>
+        /// The version string of the newest release found on GitHub.
+        /// </summary>
         public string LatestVersion { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Where we can grab the shiny new .zip file from.
+        /// </summary>
         public string DownloadUrl { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Where we can grab the cryptographic signature to ensure the update is legit.
+        /// </summary>
         public string SignatureUrl { get; private set; } = string.Empty;
 
         static UpdateService()
         {
             _httpClient = new HttpClient();
-            // GitHub API requires a User-Agent header
+            // GitHub is a bit picky and demands a User-Agent header, so we provide one politely.
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("SoundBar", "1.0"));
         }
 
+        /// <summary>
+        /// Plugs in a fake HTTP handler for our unit tests so we don't spam GitHub.
+        /// </summary>
         internal static void SetTestMessageHandler(HttpMessageHandler handler)
         {
             _httpClient = new HttpClient(handler);
             _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("SoundBar", "1.0"));
         }
 
+        /// <summary>
+        /// Checks GitHub to see if we're running an old version.
+        /// </summary>
+        /// <returns>True if a newer, signed version is available to download.</returns>
         public async Task<bool> CheckForUpdatesAsync()
         {
             try
@@ -55,6 +82,7 @@ namespace SoundBar.Services
                         var zipAsset = releaseInfo.Assets?.FirstOrDefault(a => a.Name != null && a.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
                         var sigAsset = releaseInfo.Assets?.FirstOrDefault(a => a.Name != null && a.Name.EndsWith(".sig", StringComparison.OrdinalIgnoreCase));
                         
+                        // We strictly need both the update and its signature to proceed safely.
                         if (zipAsset != null && zipAsset.BrowserDownloadUrl != null && sigAsset != null && sigAsset.BrowserDownloadUrl != null)
                         {
                             DownloadUrl = zipAsset.BrowserDownloadUrl;
@@ -66,12 +94,15 @@ namespace SoundBar.Services
             }
             catch
             {
-                // Ignore network errors or parsing errors
+                // The internet might be down, or GitHub is throwing a wobbly. We just quietly fail.
             }
 
             return false;
         }
 
+        /// <summary>
+        /// Downloads the update, verifies its signature, extracts it, and triggers the clever batch script to overwrite the running app.
+        /// </summary>
         public async Task DownloadAndApplyUpdateAsync()
         {
             if (string.IsNullOrEmpty(DownloadUrl) || string.IsNullOrEmpty(SignatureUrl)) return;
@@ -81,14 +112,14 @@ namespace SoundBar.Services
             string sigPath = Path.Combine(tempUpdateDir, "update.sig");
             string extractPath = Path.Combine(tempUpdateDir, "extracted");
 
-            // Clean up any old update folders
+            // Tidy up any debris left over from previous updates
             if (Directory.Exists(tempUpdateDir))
             {
                 try { Directory.Delete(tempUpdateDir, true); } catch { }
             }
             Directory.CreateDirectory(tempUpdateDir);
 
-            // Download the ZIP
+            // Let's grab the ZIP file
             using var response = await _httpClient.GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
 
@@ -97,7 +128,7 @@ namespace SoundBar.Services
                 await response.Content.CopyToAsync(fs);
             }
 
-            // Download the SIG
+            // Let's grab the signature file
             using var sigResponse = await _httpClient.GetAsync(SignatureUrl, HttpCompletionOption.ResponseHeadersRead);
             sigResponse.EnsureSuccessStatusCode();
 
@@ -106,7 +137,7 @@ namespace SoundBar.Services
                 await sigResponse.Content.CopyToAsync(sigFs);
             }
 
-            // Verify signature
+            // Now for the security check...
             try
             {
                 string publicKeyXml = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(PublicKeyBase64));
@@ -130,16 +161,15 @@ namespace SoundBar.Services
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Update verification failed: {ex.Message}");
-                // Cleanup and abort update process
+                // Something smells fishy. Let's abort and clean up.
                 try { Directory.Delete(tempUpdateDir, true); } catch { }
                 return;
             }
 
-            // Extract the ZIP
+            // Everything is legit, so let's extract it
             ZipFile.ExtractToDirectory(zipPath, extractPath);
 
-            // Find the actual folder containing SoundBar.exe inside the extracted zip
-            // Sometimes zips contain a root folder, sometimes just the files. We need the directory containing SoundBar.exe.
+            // We need to find the actual exe because sometimes zip files have root folders and sometimes they don't.
             string sourceDir = extractPath;
             var exeFiles = Directory.GetFiles(extractPath, "SoundBar.exe", SearchOption.AllDirectories);
             if (exeFiles.Any())
@@ -147,7 +177,7 @@ namespace SoundBar.Services
                 sourceDir = Path.GetDirectoryName(exeFiles.First()) ?? extractPath;
             }
 
-            // Create the updater batch script outside the temp folder so it doesn't delete itself
+            // We write a sneaky batch script to the temp folder. This will run independently, wait for us to close, and copy the files over.
             string currentExePath = Process.GetCurrentProcess().MainModule?.FileName ?? AppDomain.CurrentDomain.BaseDirectory;
             string currentAppDir = Path.GetDirectoryName(currentExePath) ?? AppDomain.CurrentDomain.BaseDirectory;
             string batPath = Path.Combine(Path.GetTempPath(), "SoundBar_update.bat");
@@ -183,7 +213,7 @@ del "%~f0"
 """;
             File.WriteAllText(batPath, batContent);
 
-            // Execute the batch script invisibly
+            // Fire and forget the batch script
             var processInfo = new ProcessStartInfo
             {
                 FileName = "cmd.exe",
@@ -193,11 +223,12 @@ del "%~f0"
             };
             Process.Start(processInfo);
 
-            // Terminate this application so the batch script can overwrite the files
+            // Goodbye old version! The batch script will take it from here.
             Environment.Exit(0);
         }
 
-        // Helper classes for JSON deserialization
+        // --- Helper classes just to read the GitHub API JSON ---
+
         private class GithubRelease
         {
             [JsonPropertyName("tag_name")]

--- a/src/SoundBar/Services/WindowsAudioMixerService.cs
+++ b/src/SoundBar/Services/WindowsAudioMixerService.cs
@@ -8,16 +8,23 @@ using System.Threading.Tasks;
 
 namespace SoundBar.Services
 {
+    /// <summary>
+    /// The powerhouse that actually talks to the Windows Core Audio APIs.
+    /// It hunts down active audio sessions and lets us fiddle with their volumes and mutes.
+    /// </summary>
     internal class WindowsAudioMixerService : IAudioMixerService, IDisposable
     {
-        // Cache of ProcessId -> App Info to prevent allocating heavy Process objects every tick
+        // We keep a little cache of ProcessId -> App Info so we don't have to allocate heavy Process objects every single tick.
         private readonly Dictionary<int, (string DisplayName, string RawProcessName, bool IsBackground, string? IconPath)> _processCache = new();
 
+        /// <summary>
+        /// Rummages through Windows to find every app currently hooked into the audio system.
+        /// </summary>
         public List<AudioSessionData> GetActiveAudioSessions()
         {
             var sessions = new List<AudioSessionData>();
 
-            // Track which display names we have processed to prevent duplicates
+            // We track which display names we've already seen to prevent annoying duplicates.
             var addedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Track what ProcessIds we see this tick to clean up stale cache entries
@@ -173,6 +180,9 @@ namespace SoundBar.Services
             return sessions;
         }
 
+        /// <summary>
+        /// Reaches into the guts of Windows to adjust the volume for a specific app.
+        /// </summary>
         public void SetVolume(string processName, float level)
         {
             PerformActionOnSession(processName, (volumeControl) =>
@@ -181,6 +191,9 @@ namespace SoundBar.Services
             });
         }
 
+        /// <summary>
+        /// Mutes or unmutes a specific application.
+        /// </summary>
         public void SetMute(string processName, bool isMuted)
         {
             PerformActionOnSession(processName, (volumeControl) =>
@@ -189,7 +202,7 @@ namespace SoundBar.Services
             });
         }
 
-        // Master Volume Implementation
+        // --- Master Volume Implementation ---
 
         public float GetMasterVolume()
         {

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -12,6 +12,11 @@ using Microsoft.UI.Xaml;
 
 namespace SoundBar.ViewModels
 {
+    /// <summary>
+    /// The grand orchestrator of the entire application.
+    /// It brings together the audio services, media controls, and settings,
+    /// serving everything up on a silver platter for the user interface.
+    /// </summary>
     public class MainViewModel : INotifyPropertyChanged, IDisposable
     {
         private readonly IAudioMixerService _audioService;
@@ -19,16 +24,24 @@ namespace SoundBar.ViewModels
         private readonly UpdateService _updateService;
         private readonly MediaInfoService _mediaInfoService;
 
-        // List of hidden apps
+        /// <summary>
+        /// A list of application executable names that the user prefers to keep out of sight.
+        /// </summary>
         public ObservableCollection<string> HiddenApps { get; set; }
 
-        // List of allowed background apps
+        /// <summary>
+        /// A list of background applications that the user explicitly wants to see in the mixer.
+        /// </summary>
         public ObservableCollection<string> AllowedBackgroundApps { get; set; }
 
-        // List of raw system background apps for the UI to display
+        /// <summary>
+        /// A raw list of background apps detected by the system, just so the UI can show them in settings.
+        /// </summary>
         public ObservableCollection<string> SystemBackgroundApps { get; set; }
 
-        // Special list, add/remove items here the UI auto updates itself
+        /// <summary>
+        /// The main collection of active audio applications. When we add or remove items here, the UI updates automatically.
+        /// </summary>
         public ObservableCollection<AudioAppModel> Apps { get; set; }
 
         // Saved presets
@@ -69,6 +82,30 @@ namespace SoundBar.ViewModels
                     {
                         ApplyPreset(_selectedPreset);
                     }
+                }
+            }
+        }
+
+        public List<AppTheme> AvailableThemes { get; } = new List<AppTheme>
+        {
+            AppTheme.System,
+            AppTheme.Light,
+            AppTheme.Dark
+        };
+
+        public event EventHandler<AppTheme>? ThemeChanged;
+
+        public AppTheme SelectedTheme
+        {
+            get => _settingsService.Settings.Theme;
+            set
+            {
+                if (_settingsService.Settings.Theme != value)
+                {
+                    _settingsService.Settings.Theme = value;
+                    _settingsService.SaveSettings();
+                    OnPropertyChanged();
+                    ThemeChanged?.Invoke(this, value);
                 }
             }
         }
@@ -121,6 +158,8 @@ namespace SoundBar.ViewModels
 
         public Microsoft.UI.Xaml.Visibility UpdateBannerVisibility => UpdateAvailable ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
         public string UpdateBannerText => IsUpdating ? "Downloading Update..." : $"Update Available ({LatestVersion}) - Click to Install";
+
+        public string AppVersionText => $"SoundBar {UpdateService.CurrentVersion}";
 
         // Background Image Property
         private Microsoft.UI.Xaml.Media.ImageSource? _backgroundImage;
@@ -295,7 +334,8 @@ namespace SoundBar.ViewModels
 
                     // Send command to Windows (DEBOUNCED to prevent COM/GC pressure when dragging)
                     _masterVolumeDebounce?.Cancel();
-                    _masterVolumeDebounce?.Dispose();
+                    // Don't Dispose the old CTS immediately — the in-flight Task.Delay may still
+                    // reference its Token. Let the GC collect it after the task completes.
                     _masterVolumeDebounce = new System.Threading.CancellationTokenSource();
                     var token = _masterVolumeDebounce.Token;
                     var capturedVolume = _masterVolume;
@@ -595,6 +635,34 @@ namespace SoundBar.ViewModels
             thread.Start();
         }
 
+        private void HandleAliasChanged(string rawProcessName, string newAlias)
+        {
+            if (string.IsNullOrEmpty(rawProcessName)) return;
+
+            if (string.IsNullOrWhiteSpace(newAlias))
+            {
+                // Revert to original display name if cleared
+                _settingsService.Settings.AppAliases.Remove(rawProcessName);
+                
+                var app = Apps.FirstOrDefault(a => string.Equals(a.RawProcessName, rawProcessName, StringComparison.OrdinalIgnoreCase));
+                if (app != null)
+                {
+                    // Execute on the next UI tick so the TextBox has finished its TwoWay update
+                    _dispatcherQueue.TryEnqueue(() =>
+                    {
+                        app.AliasChanged -= HandleAliasChanged; // Temporarily unsubscribe to prevent loop
+                        app.Name = app.DisplayName;
+                        app.AliasChanged += HandleAliasChanged;
+                    });
+                }
+            }
+            else
+            {
+                _settingsService.Settings.AppAliases[rawProcessName] = newAlias;
+            }
+            _settingsService.SaveSettings();
+        }
+
         private void UpdateCollection(List<AudioSessionData> latestSessions)
         {
             // Remove apps that are no longer running
@@ -603,8 +671,8 @@ namespace SoundBar.ViewModels
             {
                 var existingApp = Apps[i];
 
-                // If existing app is not in the new list (match by Name since ProcessId might fluctuate for multi-process apps like Discord)
-                if (!latestSessions.Any(x => string.Equals(x.DisplayName, existingApp.Name, StringComparison.OrdinalIgnoreCase)))
+                // If existing app is not in the new list (match by RawProcessName since DisplayName can change and Name is now an alias)
+                if (!latestSessions.Any(x => string.Equals(x.RawProcessName, existingApp.RawProcessName, StringComparison.OrdinalIgnoreCase)))
                 {
                     bool isProcessDead = true;
                         // FAST PATH: Check if the specific process ID we started with is still running
@@ -665,7 +733,7 @@ namespace SoundBar.ViewModels
                         }
                         
                         // Remove from active Apps if it was previously there
-                        var existingBg = Apps.FirstOrDefault(a => string.Equals(a.Name, sessionData.DisplayName, StringComparison.OrdinalIgnoreCase));
+                        var existingBg = Apps.FirstOrDefault(a => string.Equals(a.RawProcessName, sessionData.RawProcessName, StringComparison.OrdinalIgnoreCase));
                         if (existingBg != null) Apps.Remove(existingBg);
                         
                         continue;
@@ -675,23 +743,32 @@ namespace SoundBar.ViewModels
                 // Skip if this app is hidden by the user
                 if (HiddenApps.Any(a => string.Equals(a, sessionData.DisplayName, StringComparison.OrdinalIgnoreCase)))
                 {
-                    var existingHidden = Apps.FirstOrDefault(a => string.Equals(a.Name, sessionData.DisplayName, StringComparison.OrdinalIgnoreCase));
+                    var existingHidden = Apps.FirstOrDefault(a => string.Equals(a.RawProcessName, sessionData.RawProcessName, StringComparison.OrdinalIgnoreCase));
                     if (existingHidden != null) Apps.Remove(existingHidden);
                     continue;
                 }
 
                 // If this app is not in our current UI list, create a new AudioAppModel for it
-                if (!Apps.Any(x => string.Equals(x.Name, sessionData.DisplayName, StringComparison.OrdinalIgnoreCase)))
+                if (!Apps.Any(x => string.Equals(x.RawProcessName, sessionData.RawProcessName, StringComparison.OrdinalIgnoreCase)))
                 {
+                    // Check if there is a saved alias
+                    string aliasName = _settingsService.Settings.AppAliases.TryGetValue(sessionData.RawProcessName ?? "", out var alias) ? alias : sessionData.DisplayName;
+
                     // ONLY place where AudioAppModel is created — for genuinely new apps
                     var newApp = new AudioAppModel(_audioService)
                     {
                         ProcessId = sessionData.ProcessId,
                         IsBackgroundApp = sessionData.IsBackgroundApp,
-                        Name = sessionData.DisplayName,
+                        DisplayName = sessionData.DisplayName,
                         RawProcessName = sessionData.RawProcessName,
                         IconPath = sessionData.IconPath
                     };
+                    
+                    // Set Name BEFORE assigning AliasChanged so the initial set
+                    // doesn't trigger a save to config.json for every app
+                    newApp.Name = aliasName;
+                    newApp.AliasChanged = HandleAliasChanged;
+
                     // Set volume/mute via backing fields to avoid triggering OS write-back
                     newApp.SyncVolumeFromOS(sessionData.Volume);
                     newApp.SyncMuteFromOS(sessionData.IsMuted);
@@ -701,8 +778,8 @@ namespace SoundBar.ViewModels
                 }
                 else
                 {
-                    // Update existing app (match by Name because ProcessId can change if the app restarts)
-                    var existingApp = Apps.First(x => string.Equals(x.Name, sessionData.DisplayName, StringComparison.OrdinalIgnoreCase));
+                    // Update existing app (match by RawProcessName)
+                    var existingApp = Apps.First(x => string.Equals(x.RawProcessName, sessionData.RawProcessName, StringComparison.OrdinalIgnoreCase));
 
                     // Check if the session just came back to life after being destroyed (e.g. tabbing back into a game)
                     if (!existingApp.IsSessionAlive)
@@ -744,7 +821,7 @@ namespace SoundBar.ViewModels
             _settingsService.SaveSettings();
 
             // Check if it's currently in the Apps list and remove it
-            var appToRemove = Apps.FirstOrDefault(a => string.Equals(a.Name, appName, StringComparison.OrdinalIgnoreCase));
+            var appToRemove = Apps.FirstOrDefault(a => string.Equals(a.DisplayName, appName, StringComparison.OrdinalIgnoreCase));
             if (appToRemove != null)
             {
                 Apps.Remove(appToRemove);
@@ -801,9 +878,9 @@ namespace SoundBar.ViewModels
 
             foreach (var app in Apps)
             {
-                if (!string.IsNullOrEmpty(app.Name))
+                if (!string.IsNullOrEmpty(app.RawProcessName))
                 {
-                    newPreset.AppVolumes[app.Name] = app.Volume;
+                    newPreset.AppVolumes[app.RawProcessName] = app.Volume;
                 }
             }
 
@@ -831,9 +908,9 @@ namespace SoundBar.ViewModels
             // Apply App Volumes
             foreach (var app in Apps)
             {
-                if (!string.IsNullOrEmpty(app.Name) && preset.AppVolumes.ContainsKey(app.Name))
+                if (!string.IsNullOrEmpty(app.RawProcessName) && preset.AppVolumes.ContainsKey(app.RawProcessName))
                 {
-                    app.Volume = preset.AppVolumes[app.Name];
+                    app.Volume = preset.AppVolumes[app.RawProcessName];
                     app.PushVolumeToOS(); // Force OS to sync immediately
                 }
             }
@@ -1020,7 +1097,12 @@ namespace SoundBar.ViewModels
 
         public void SeekToScrubPosition()
         {
-            _ = _mediaInfoService.SeekAsync(TimeSpan.FromSeconds(CurrentSongPositionSeconds));
+            var seekPosition = TimeSpan.FromSeconds(CurrentSongPositionSeconds);
+            // Update base position immediately so ProgressTimer_Tick doesn't
+            // snap the slider back to the old position before the OS reports the new one
+            _basePosition = seekPosition;
+            _lastUpdatedTime = DateTimeOffset.Now;
+            _ = _mediaInfoService.SeekAsync(seekPosition);
         }
 
         private void MediaInfoService_MediaInfoChanged(object? sender, MediaInfoEventArgs e)
@@ -1108,6 +1190,16 @@ namespace SoundBar.ViewModels
             _pollingCts?.Cancel();
             _pollingCts?.Dispose();
             _pollingCts = null;
+
+            _progressTimer?.Stop();
+
+            _mediaInfoService?.Dispose();
+
+            // Dispose all AudioAppModels to cancel any in-flight debounce tasks
+            foreach (var app in Apps)
+            {
+                app.Dispose();
+            }
 
             if (_audioService is IDisposable disposable)
             {

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -1,16 +1,31 @@
 <Window x:Class="SoundBar.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    
-    <Border Background="#2D2D30" 
-            BorderBrush="#444444" 
+
+    <Border Background="{ThemeResource LayerFillColorDefaultBrush}" 
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" 
             BorderThickness="1">
+        <Border.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.ThemeDictionaries>
+                    <ResourceDictionary x:Key="Light">
+                        <SolidColorBrush x:Key="DimmingOverlayBrush" Color="#D8EAEAEA" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="Dark">
+                        <SolidColorBrush x:Key="DimmingOverlayBrush" Color="#D8202020" />
+                    </ResourceDictionary>
+                    <ResourceDictionary x:Key="Default">
+                        <SolidColorBrush x:Key="DimmingOverlayBrush" Color="#D8202020" />
+                    </ResourceDictionary>
+                </ResourceDictionary.ThemeDictionaries>
+            </ResourceDictionary>
+        </Border.Resources>
 
         <Grid>
             <!-- Background Image Layer -->
             <Image Stretch="UniformToFill" Source="{x:Bind ViewModel.BackgroundImage, Mode=OneWay}" />
             <!-- Dimming Overlay Layer -->
-            <Border Background="#D8202020" />
+            <Border Background="{ThemeResource DimmingOverlayBrush}" />
 
             <!-- Application Content -->
             <Grid>
@@ -28,24 +43,41 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Grid.Column="0"
                            Text="SoundBar" 
-                           Foreground="White" 
+                           Foreground="{ThemeResource TextFillColorPrimaryBrush}" 
                            VerticalAlignment="Center" 
                            Margin="0"
                            FontSize="20"
                            FontWeight="Bold"/>
 
-                <Button x:Name="SettingsButton"
+                <Button x:Name="UpdateButton"
                         Grid.Column="1"
+                        Content="&#xE896;" 
+                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                        Width="36" Height="36"
+                        Padding="0" MinWidth="0" MinHeight="0"
+                        Background="#1F6B2C"
+                        Foreground="White"
+                        BorderThickness="0"
+                        CornerRadius="4"
+                        FontSize="14"
+                        Margin="0,0,10,0"
+                        Click="UpdateBanner_Click"
+                        Visibility="{x:Bind ViewModel.UpdateBannerVisibility, Mode=OneWay}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.UpdateBannerText, Mode=OneWay}"/>
+
+                <Button x:Name="SettingsButton"
+                        Grid.Column="2"
                         Content="&#xE713;" 
                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                         Width="36" Height="36"
                         Padding="0" MinWidth="0" MinHeight="0"
                         Background="Transparent"
-                        Foreground="#AAAAAA"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         BorderThickness="0"
                         FontSize="14"
                         Margin="0,0,5,0"
@@ -53,13 +85,13 @@
                         ToolTipService.ToolTip="Settings"/>
 
                 <Button x:Name="PinButton"
-                        Grid.Column="2"
+                        Grid.Column="3"
                         Content="&#xE718;" 
                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                         Width="36" Height="36"
                         Padding="0" MinWidth="0" MinHeight="0"
                         Background="Transparent"
-                        Foreground="#555555"
+                        Foreground="{ThemeResource TextFillColorDisabledBrush}"
                         BorderThickness="0"
                         FontSize="16"
                         Margin="0,0,5,0"
@@ -67,13 +99,13 @@
                         ToolTipService.ToolTip="Always on Top"/>
 
                 <ToggleButton x:Name="DndToggleButton"
-                              Grid.Column="3"
+                              Grid.Column="4"
                               Content="&#xE708;" 
                               FontFamily="{ThemeResource SymbolThemeFontFamily}"
                               Width="36" Height="36"
                               Padding="0" MinWidth="0" MinHeight="0"
                               Background="Transparent"
-                              Foreground="#555555"
+                              Foreground="{ThemeResource TextFillColorDisabledBrush}"
                               BorderThickness="0"
                               FontSize="14"
                               Margin="0,0,5,0"
@@ -83,24 +115,24 @@
                               ToolTipService.ToolTip="Do Not Disturb (Mute System Sounds)"/>
 
                 <Button x:Name="MinimizeButton"
-                        Grid.Column="4"
+                        Grid.Column="5"
                         Content="&#xE921;" 
                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                         Width="36" Height="36"
                         Padding="0" MinWidth="0" MinHeight="0"
                         Background="Transparent"
-                        Foreground="#AAAAAA"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         BorderThickness="0"
                         FontSize="14"
                         Click="MinimizeButton_Click"/>
 
-                <Button Grid.Column="5"
+                <Button Grid.Column="6"
                         Content="&#xE711;" 
                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                         Width="36" Height="36"
                         Padding="0" MinWidth="0" MinHeight="0"
                         Background="Transparent"
-                        Foreground="#AAAAAA"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         BorderThickness="0"
                         FontSize="14"
                         Click="CloseButton_Click"/>
@@ -122,21 +154,6 @@
                     </Grid.RowDefinitions>
                     
                     <StackPanel Grid.Row="0">
-                    <Button Background="#1F6B2C" 
-                            Foreground="White" 
-                            BorderThickness="0"
-                            HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Center"
-                            Margin="0,0,0,15"
-                            Padding="5"
-                            CornerRadius="4"
-                            Click="UpdateBanner_Click"
-                            Visibility="{x:Bind ViewModel.UpdateBannerVisibility, Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE896;" VerticalAlignment="Center" />
-                            <TextBlock Text="{x:Bind ViewModel.UpdateBannerText, Mode=OneWay}" VerticalAlignment="Center" FontWeight="SemiBold"/>
-                        </StackPanel>
-                    </Button>
 
                     <Border Background="#66FF0000"
                             BorderBrush="#FF5555"
@@ -146,14 +163,14 @@
                             Padding="10"
                             Visibility="{x:Bind ViewModel.LoudnessWarningVisibility, Mode=OneWay}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xEA39;" Foreground="White" VerticalAlignment="Center" FontSize="16"/>
-                            <TextBlock Text="Volume has been very high for a while. Protect your hearing!" Foreground="White" VerticalAlignment="Center" TextWrapping="Wrap" Width="200"/>
-                            <Button Content="Dismiss" Background="#44000000" Foreground="White" BorderThickness="0" VerticalAlignment="Center" Click="DismissLoudnessWarning_Click"/>
+                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xEA39;" Foreground="{ThemeResource TextFillColorPrimaryBrush}" VerticalAlignment="Center" FontSize="16"/>
+                            <TextBlock Text="Volume has been very high for a while. Protect your hearing!" Foreground="{ThemeResource TextFillColorPrimaryBrush}" VerticalAlignment="Center" TextWrapping="Wrap" Width="200"/>
+                            <Button Content="Dismiss" Background="{ThemeResource ControlFillColorSecondaryBrush}" Foreground="{ThemeResource TextFillColorPrimaryBrush}" BorderThickness="0" VerticalAlignment="Center" Click="DismissLoudnessWarning_Click"/>
                         </StackPanel>
                     </Border>
 
                     <TextBlock Text="Output Device" 
-                               Foreground="#DDDDDD" 
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                FontSize="14" 
                                FontWeight="SemiBold"
                                Margin="0,0,0,5"/>
@@ -163,14 +180,14 @@
                               SelectedItem="{Binding SelectedAudioDevice, Mode=TwoWay}"
                               DisplayMemberPath="Name"
                               PlaceholderText="Select Output Device..."
-                              Background="#333333"
+                              Background="{ThemeResource ControlFillColorDefaultBrush}"
                               BorderThickness="1"
-                              BorderBrush="#555555"
-                              Foreground="#DDDDDD"
+                              BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                               Margin="0,0,0,15"/>
 
                     <TextBlock Text="Master Volume" 
-                               Foreground="#DDDDDD" 
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                FontSize="14" 
                                FontWeight="SemiBold"
                                Margin="0,0,0,5"/>
@@ -188,7 +205,7 @@
                                 Margin="0,0,10,0"/>
 
                         <TextBlock Grid.Column="1" 
-                                   Foreground="#AAAAAA"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Right">
                             <Run Text="{Binding MasterVolumePercentage}" /><Run Text="%" />
@@ -199,7 +216,7 @@
 
                     <Grid Margin="0,0,0,10">
                         <TextBlock Text="Active Apps" 
-                                   Foreground="#DDDDDD" 
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                    FontSize="14" 
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"/>
@@ -222,7 +239,7 @@
                                             Content="&#xE74D;" 
                                             FontFamily="{ThemeResource SymbolThemeFontFamily}" 
                                             Background="Transparent" 
-                                            Foreground="#777777" 
+                                            Foreground="{ThemeResource TextFillColorTertiaryBrush}" 
                                             BorderThickness="0" 
                                             Click="HideAppButton_Click" 
                                             ToolTipService.ToolTip="Hide App" 
@@ -232,10 +249,17 @@
 
                                     <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
                                         <Image Source="{Binding AppIcon}" Width="20" Height="20" Margin="0,0,8,0" Stretch="Uniform"/>
-                                        <TextBlock Text="{Binding Name}" 
-                                                   Foreground="White"
-                                                   VerticalAlignment="Center"
-                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBox Text="{Binding Name, Mode=TwoWay}" 
+                                                 Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                                 Background="Transparent"
+                                                 BorderThickness="0"
+                                                 VerticalAlignment="Center"
+                                                 MinHeight="0"
+                                                 MinWidth="0"
+                                                 Padding="0"
+                                                 Margin="0"
+                                                 KeyDown="TextBox_KeyDown"
+                                                 ToolTipService.ToolTip="Click to rename"/>
                                     </StackPanel>
 
                                     <Slider Grid.Column="2" 
@@ -245,7 +269,7 @@
                                             Margin="10,0"/>
 
                                     <TextBlock Grid.Column="3" 
-                                               Foreground="#AAAAAA"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                VerticalAlignment="Center"
                                                HorizontalAlignment="Right">
                                         <Run Text="{Binding VolumePercentage}" /><Run Text="%" />
@@ -269,7 +293,7 @@
                     <!-- Album Art -->
                     <Viewbox Grid.Row="0" Margin="10" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="280">
                         <Grid>
-                            <Border CornerRadius="12" Background="#222222" Width="250" Height="250">
+                            <Border CornerRadius="12" Background="{ThemeResource LayerFillColorAltBrush}" Width="250" Height="250">
                                 <Image Source="{x:Bind ViewModel.CurrentSongThumbnail, Mode=OneWay}" Stretch="UniformToFill">
                                     <ToolTipService.ToolTip>
                                         <ToolTip Content="No Artwork Available" />
@@ -282,10 +306,10 @@
                     </Viewbox>
 
                     <!-- Title -->
-                    <TextBlock Grid.Row="1" Text="{x:Bind ViewModel.CurrentSongTitle, Mode=OneWay}" FontSize="24" FontWeight="Bold" Foreground="White" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,5"/>
+                    <TextBlock Grid.Row="1" Text="{x:Bind ViewModel.CurrentSongTitle, Mode=OneWay}" FontSize="24" FontWeight="Bold" Foreground="{ThemeResource TextFillColorPrimaryBrush}" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,5"/>
 
                     <!-- Artist -->
-                    <TextBlock Grid.Row="2" Text="{x:Bind ViewModel.CurrentSongArtist, Mode=OneWay}" FontSize="16" Foreground="#AAAAAA" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,15"/>
+                    <TextBlock Grid.Row="2" Text="{x:Bind ViewModel.CurrentSongArtist, Mode=OneWay}" FontSize="16" Foreground="{ThemeResource TextFillColorSecondaryBrush}" HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Margin="0,0,0,15"/>
 
                     <!-- Scrub Bar -->
                     <Grid Grid.Row="3" Margin="20,0,20,10">
@@ -295,18 +319,18 @@
                             <ColumnDefinition Width="50"/>
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" Text="{x:Bind ViewModel.CurrentSongPositionText, Mode=OneWay}" Foreground="#888888" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,10,0"/>
+                        <TextBlock Grid.Column="0" Text="{x:Bind ViewModel.CurrentSongPositionText, Mode=OneWay}" Foreground="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,0,10,0"/>
                         
-                        <Slider Grid.Column="1" 
+                        <Slider x:Name="SongPositionSlider"
+                                Grid.Column="1" 
                                 Minimum="0" 
                                 Maximum="{x:Bind ViewModel.CurrentSongDurationSeconds, Mode=OneWay}" 
                                 Value="{x:Bind ViewModel.CurrentSongPositionSeconds, Mode=TwoWay}"
                                 ThumbToolTipValueConverter="{StaticResource TimeSpanConverter}"
-                                PointerPressed="SongPositionSlider_PointerPressed"
                                 PointerCaptureLost="SongPositionSlider_PointerCaptureLost"
                                 VerticalAlignment="Center" />
 
-                        <TextBlock Grid.Column="2" Text="{x:Bind ViewModel.CurrentSongDurationText, Mode=OneWay}" Foreground="#888888" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="10,0,0,0"/>
+                        <TextBlock Grid.Column="2" Text="{x:Bind ViewModel.CurrentSongDurationText, Mode=OneWay}" Foreground="{ThemeResource TextFillColorTertiaryBrush}" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="10,0,0,0"/>
                     </Grid>
                 </Grid>
 
@@ -322,7 +346,7 @@
                                 Content="&#xE8D6;" 
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}" 
                                 Background="Transparent" 
-                                Foreground="#888888" 
+                                Foreground="{ThemeResource TextFillColorTertiaryBrush}" 
                                 BorderThickness="0" 
                                 FontSize="18"
                                 Width="36" Height="36"
@@ -334,10 +358,10 @@
                         <!-- Previous -->
                         <Button Content="&#xE892;" 
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                                Background="#44000000" 
-                                Foreground="#DDDDDD" 
+                                Background="{ThemeResource ControlFillColorSecondaryBrush}" 
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                 BorderThickness="1"
-                                BorderBrush="#33FFFFFF" 
+                                BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}" 
                                 CornerRadius="18"
                                 FontSize="14"
                                 Width="36" Height="36"
@@ -346,27 +370,27 @@
                                 ToolTipService.ToolTip="Previous Track" />
 
                         <!-- Play/Pause -->
-                        <Button Background="#44000000" 
+                        <Button Background="{ThemeResource ControlFillColorSecondaryBrush}" 
                                 BorderThickness="1"
-                                BorderBrush="#33FFFFFF" 
+                                BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}" 
                                 CornerRadius="18"
                                 Width="36" Height="36"
                                 Padding="0" MinWidth="0" MinHeight="0"
                                 Click="MediaPlayPause_Click" 
                                 ToolTipService.ToolTip="Play / Pause">
                             <StackPanel Orientation="Horizontal" Spacing="2" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE768;" FontSize="12" Foreground="#DDDDDD"/>
-                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE769;" FontSize="12" Foreground="#DDDDDD"/>
+                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE768;" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE769;" FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                             </StackPanel>
                         </Button>
 
                         <!-- Next -->
                         <Button Content="&#xE893;" 
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                                Background="#44000000" 
-                                Foreground="#DDDDDD" 
+                                Background="{ThemeResource ControlFillColorSecondaryBrush}" 
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                 BorderThickness="1"
-                                BorderBrush="#33FFFFFF" 
+                                BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}" 
                                 CornerRadius="18"
                                 FontSize="14"
                                 Width="36" Height="36"
@@ -377,10 +401,10 @@
                         <!-- Mute -->
                         <Button Content="&#xE74F;" 
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}" 
-                                Background="#44000000" 
-                                Foreground="#DDDDDD" 
+                                Background="{ThemeResource ControlFillColorSecondaryBrush}" 
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" 
                                 BorderThickness="1"
-                                BorderBrush="#33FFFFFF" 
+                                BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}" 
                                 CornerRadius="18"
                                 FontSize="14"
                                 Width="36" Height="36"
@@ -403,14 +427,14 @@
                     <Button Content="&#xE72B;" 
                             FontFamily="{ThemeResource SymbolThemeFontFamily}"
                             Background="Transparent"
-                            Foreground="#AAAAAA"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             BorderThickness="0"
                             Padding="5"
                             FontSize="18"
                             Margin="0,0,10,0"
                             Click="CloseSettingsButton_Click"/>
                     <TextBlock Text="Settings" 
-                               Foreground="White" 
+                               Foreground="{ThemeResource TextFillColorPrimaryBrush}" 
                                FontSize="18" 
                                FontWeight="Bold"
                                VerticalAlignment="Center"/>
@@ -418,55 +442,72 @@
 
                 <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="0,0,10,0">
                     <StackPanel Spacing="10">
-                        <!-- Hearing Protection -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <!-- Theme Settings -->
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="Hearing Protection" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="Appearance" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Shows a warning if your master volume stays above 85% for an extended time." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Choose whether the app should follow your system settings or force Light/Dark mode." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <ComboBox HorizontalAlignment="Stretch"
+                                          ItemsSource="{Binding AvailableThemes}"
+                                          SelectedItem="{Binding SelectedTheme, Mode=TwoWay}"
+                                          Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                          BorderThickness="1"
+                                          BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                            </StackPanel>
+                        </Expander>
+
+                        <!-- Hearing Protection -->
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
+                            <Expander.Header>
+                                <TextBlock Text="Hearing Protection" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
+                            </Expander.Header>
+                            <StackPanel>
+                                <TextBlock Text="Shows a warning if your master volume stays above 85% for an extended time." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <ToggleSwitch Header="Excessive Loudness Warning" 
                                               IsOn="{x:Bind ViewModel.IsLoudnessWarningEnabled, Mode=TwoWay}" 
-                                              Foreground="White"/>
+                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                             </StackPanel>
                         </Expander>
 
                         <!-- Custom Background -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="Custom Background" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="Custom Background" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Place a .jpg or .png image in the backgrounds folder to personalise your SoundBar." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Place a .jpg or .png image in the backgrounds folder to personalise your SoundBar." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <Grid Margin="0,5">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="10"/>
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
-                                    <Button Grid.Column="0" Content="Open Folder" HorizontalAlignment="Stretch" Background="#333333" Foreground="White" BorderThickness="0" Click="OpenBackgroundFolder_Click"/>
-                                    <Button Grid.Column="2" Content="Reload" HorizontalAlignment="Stretch" Background="#333333" Foreground="White" BorderThickness="0" Click="ReloadBackground_Click"/>
+                                    <Button Grid.Column="0" Content="Open Folder" HorizontalAlignment="Stretch" Background="{ThemeResource ControlFillColorDefaultBrush}" Foreground="{ThemeResource TextFillColorPrimaryBrush}" BorderThickness="0" Click="OpenBackgroundFolder_Click"/>
+                                    <Button Grid.Column="2" Content="Reload" HorizontalAlignment="Stretch" Background="{ThemeResource ControlFillColorDefaultBrush}" Foreground="{ThemeResource TextFillColorPrimaryBrush}" BorderThickness="0" Click="ReloadBackground_Click"/>
                                 </Grid>
                             </StackPanel>
                         </Expander>
 
                         <!-- Hidden Apps -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="Hidden Apps" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="Hidden Apps" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Apps that you have manually hidden from the mixer." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Apps that you have manually hidden from the mixer." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <ItemsControl ItemsSource="{Binding HiddenApps}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <Grid Margin="0,5">
-                                                <TextBlock Text="{Binding}" VerticalAlignment="Center" Foreground="White"/>
+                                                <TextBlock Text="{Binding}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                                                 <Button Content="Unhide" 
                                                         Click="UnhideAppButton_Click" 
                                                         HorizontalAlignment="Right" 
-                                                        Background="#333333" 
-                                                        Foreground="White" 
+                                                        Background="{ThemeResource ControlFillColorDefaultBrush}" 
+                                                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" 
                                                         BorderThickness="0"/>
                                             </Grid>
                                         </DataTemplate>
@@ -476,22 +517,22 @@
                         </Expander>
 
                         <!-- Background Apps Second -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="Background Apps" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="Background Apps" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Apps that are running in the background and not outputting audio yet." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Apps that are running in the background and not outputting audio yet." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <ItemsControl ItemsSource="{Binding SystemBackgroundApps}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <Grid Margin="0,5">
-                                                <TextBlock Text="{Binding}" VerticalAlignment="Center" Foreground="White" TextTrimming="CharacterEllipsis" MaxWidth="180" HorizontalAlignment="Left" />
+                                                <TextBlock Text="{Binding}" VerticalAlignment="Center" Foreground="{ThemeResource TextFillColorPrimaryBrush}" TextTrimming="CharacterEllipsis" MaxWidth="180" HorizontalAlignment="Left" />
                                                 <Button Content="Allow" 
                                                         Click="AllowBackgroundAppButton_Click" 
                                                         HorizontalAlignment="Right" 
-                                                        Background="#333333" 
-                                                        Foreground="White" 
+                                                        Background="{ThemeResource ControlFillColorDefaultBrush}" 
+                                                        Foreground="{ThemeResource TextFillColorPrimaryBrush}" 
                                                         BorderThickness="0"/>
                                             </Grid>
                                         </DataTemplate>
@@ -501,33 +542,42 @@
                         </Expander>
 
                         <!-- Media Controls Settings -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="Media Controls" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="Media Controls" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Shows global media controls at the bottom of the application (Previous, Play/Pause, Next, Mute)." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Shows global media controls at the bottom of the application (Previous, Play/Pause, Next, Mute)." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <ToggleSwitch Header="Show Media Controls" 
                                               IsOn="{x:Bind ViewModel.ShowMediaControls, Mode=TwoWay}" 
-                                              Foreground="White"/>
+                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                             </StackPanel>
                         </Expander>
 
                         <!-- System Integration Settings -->
-                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="#252525" BorderThickness="1" BorderBrush="#444444">
+                        <Expander HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}">
                             <Expander.Header>
-                                <TextBlock Text="System Startup" Foreground="White" FontSize="14" FontWeight="SemiBold"/>
+                                <TextBlock Text="System Startup" Foreground="{ThemeResource TextFillColorPrimaryBrush}" FontSize="14" FontWeight="SemiBold"/>
                             </Expander.Header>
                             <StackPanel>
-                                <TextBlock Text="Automatically start SoundBar in the background when you log into Windows." Foreground="#AAAAAA" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <TextBlock Text="Automatically start SoundBar in the background when you log into Windows." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
                                 <ToggleSwitch Header="Run at Startup" 
                                               IsOn="{x:Bind ViewModel.RunAtStartup, Mode=TwoWay}" 
-                                              Foreground="White"/>
+                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                             </StackPanel>
                         </Expander>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>
+
+            <!-- App Version (Global) -->
+            <TextBlock Grid.Row="1"
+                       Text="{x:Bind ViewModel.AppVersionText, Mode=OneWay}" 
+                       Foreground="{ThemeResource TextFillColorDisabledBrush}" 
+                       FontSize="10" 
+                       HorizontalAlignment="Right" 
+                       VerticalAlignment="Bottom"
+                       Margin="0,0,10,5"/>
             </Grid>
         </Grid>
     </Border>

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -16,16 +16,23 @@ using SoundBar.Helpers;
 
 namespace SoundBar.Views
 {
+    /// <summary>
+    /// The main window of our application where all the action happens.
+    /// It handles all the UI interactions, dragging, and passing commands down to the ViewModel.
+    /// </summary>
     public sealed partial class MainWindow : Window
     {
-        // View Model accessor
+        /// <summary>
+        /// Our connection to the brains of the operation.
+        /// </summary>
         public MainViewModel ViewModel { get; }
 
-        // Dependencies
         private readonly SettingsService _settingsService;
         private AppWindow _appWindow;
 
-        // Constructor
+        /// <summary>
+        /// Sets up the window, wires up the ViewModel, and restores our saved settings.
+        /// </summary>
         public MainWindow()
         {
             this.InitializeComponent();
@@ -33,6 +40,10 @@ namespace SoundBar.Views
             _settingsService = new SettingsService();
             ViewModel = new MainViewModel(_settingsService);
             ((FrameworkElement)this.Content).DataContext = ViewModel;
+
+            // Apply initial theme and listen for changes
+            ApplyTheme(ViewModel.SelectedTheme);
+            ViewModel.ThemeChanged += (s, theme) => ApplyTheme(theme);
 
             this.ExtendsContentIntoTitleBar = true;
             this.SetTitleBar(null);
@@ -58,6 +69,24 @@ namespace SoundBar.Views
                 presenter.SetBorderAndTitleBar(true, false);
             }
 
+            RestoreWindowPosition();
+        }
+
+        private void ApplyTheme(AppTheme theme)
+        {
+            if (this.Content is FrameworkElement rootElement)
+            {
+                rootElement.RequestedTheme = theme switch
+                {
+                    AppTheme.Light => ElementTheme.Light,
+                    AppTheme.Dark => ElementTheme.Dark,
+                    _ => ElementTheme.Default,
+                };
+            }
+        }
+
+        private void RestoreWindowPosition()
+        {
             LoadWindowSettings();
             
             TitleBarGrid.PointerPressed += TitleBarGrid_PointerPressed;
@@ -66,6 +95,8 @@ namespace SoundBar.Views
             TitleBarGrid.PointerCanceled += TitleBarGrid_PointerCanceled;
 
             this.Closed += (s, e) => { ViewModel.Dispose(); };
+
+            SongPositionSlider.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(SongPositionSlider_PointerPressed), true);
 
             CreateDesktopShortcut();
         }
@@ -222,7 +253,7 @@ namespace SoundBar.Views
         {
             if ((sender as Button)?.DataContext is AudioAppModel app)
             {
-                ViewModel.HideApp(app.Name ?? string.Empty);
+                ViewModel.HideApp(app.DisplayName ?? string.Empty);
             }
         }
 
@@ -388,6 +419,16 @@ namespace SoundBar.Views
         {
             ViewModel.IsUserScrubbing = false;
             ViewModel.SeekToScrubPosition();
+        }
+
+        private void TextBox_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == Windows.System.VirtualKey.Enter)
+            {
+                // Force focus back to the main content grid to trigger LostFocus binding update
+                MainContentGrid.Focus(FocusState.Programmatic);
+                e.Handled = true;
+            }
         }
     }
 }

--- a/tests/SoundBar.Tests/AudioAppModelTests.cs
+++ b/tests/SoundBar.Tests/AudioAppModelTests.cs
@@ -90,5 +90,159 @@ namespace SoundBar.Tests
             mockService.Verify(s => s.SetVolume("test.exe", 0.2f), Times.Never);
             mockService.Verify(s => s.SetVolume("test.exe", 0.4f), Times.Never);
         }
+
+        // --- New v2.4.0 Tests ---
+
+        [Fact]
+        public void NameSetter_WhenChanged_FiresAliasChangedCallback()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "game.exe",
+                DisplayName = "Game"
+            };
+
+            string? capturedProcessName = null;
+            string? capturedAlias = null;
+            model.AliasChanged = (processName, alias) =>
+            {
+                capturedProcessName = processName;
+                capturedAlias = alias;
+            };
+
+            // Act
+            model.Name = "My Custom Name";
+
+            // Assert
+            Assert.Equal("game.exe", capturedProcessName);
+            Assert.Equal("My Custom Name", capturedAlias);
+        }
+
+        [Fact]
+        public void NameSetter_WhenSameValue_DoesNotFireCallback()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "game.exe",
+                Name = "Original"
+            };
+
+            int callCount = 0;
+            model.AliasChanged = (_, _) => callCount++;
+
+            // Act — set to the same value
+            model.Name = "Original";
+
+            // Assert — callback should NOT have fired
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public void DisplayName_RemainsStable_AfterNameAliasChange()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "hl2.exe",
+                DisplayName = "Hl2"
+            };
+
+            // Act — change the alias (Name)
+            model.Name = "Half Life 2";
+
+            // Assert — DisplayName should NOT have changed
+            Assert.Equal("Hl2", model.DisplayName);
+            Assert.Equal("Half Life 2", model.Name);
+        }
+
+        [Fact]
+        public void PushVolumeToOS_UsesRawProcessName_NotAlias()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "chrome.exe",
+                DisplayName = "Chrome",
+                Name = "My Browser" // User alias
+            };
+            model.SyncVolumeFromOS(0.75f);
+
+            // Act
+            model.PushVolumeToOS();
+
+            // Assert — should use "chrome.exe" (RawProcessName), not "My Browser" (alias)
+            mockService.Verify(s => s.SetVolume("chrome.exe", 0.75f), Times.Once);
+        }
+
+        [Fact]
+        public void IsMutedSetter_UsesRawProcessName_NotAlias()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "spotify.exe",
+                DisplayName = "Spotify",
+                Name = "Music Player" // User alias
+            };
+
+            // Act
+            model.IsMuted = true;
+
+            // Assert — should use "spotify.exe" not "Music Player"
+            mockService.Verify(s => s.SetMute("spotify.exe", true), Times.Once);
+        }
+
+        [Fact]
+        public void VolumePercentage_RoundTrip_Boundaries()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "test.exe"
+            };
+
+            // Act & Assert — 0%
+            model.VolumePercentage = 0;
+            Assert.Equal(0f, model.Volume);
+            Assert.Equal(0, model.VolumePercentage);
+
+            // Act & Assert — 50%
+            model.VolumePercentage = 50;
+            Assert.Equal(0.5f, model.Volume);
+            Assert.Equal(50, model.VolumePercentage);
+
+            // Act & Assert — 100%
+            model.VolumePercentage = 100;
+            Assert.Equal(1.0f, model.Volume);
+            Assert.Equal(100, model.VolumePercentage);
+        }
+
+        [Fact]
+        public void Dispose_CancelsDebounce()
+        {
+            // Arrange
+            var mockService = new Mock<IAudioMixerService>();
+            var model = new AudioAppModel(mockService.Object)
+            {
+                RawProcessName = "test.exe"
+            };
+
+            // Trigger a volume change to create a debounce CTS
+            model.Volume = 0.5f;
+
+            // Act — dispose should not throw
+            model.Dispose();
+
+            // Assert — calling Dispose again should be safe (idempotent)
+            model.Dispose();
+        }
     }
 }

--- a/tests/SoundBar.Tests/SettingsServiceTests.cs
+++ b/tests/SoundBar.Tests/SettingsServiceTests.cs
@@ -71,5 +71,61 @@ namespace SoundBar.Tests
             Assert.NotNull(service.Settings);
             Assert.False(service.Settings.IsPinned); // Default state
         }
+
+        // --- New v2.4.0 Tests ---
+
+        [Fact]
+        public void SaveAndLoad_AppAliases_PersistsCorrectly()
+        {
+            // Arrange
+            var service1 = new SettingsService(_testFilePath);
+            service1.Settings.AppAliases["chrome.exe"] = "Browser";
+            service1.Settings.AppAliases["hl2.exe"] = "Half Life 2";
+
+            // Act
+            service1.SaveSettings();
+            var service2 = new SettingsService(_testFilePath);
+
+            // Assert
+            Assert.Equal(2, service2.Settings.AppAliases.Count);
+            Assert.Equal("Browser", service2.Settings.AppAliases["chrome.exe"]);
+            Assert.Equal("Half Life 2", service2.Settings.AppAliases["hl2.exe"]);
+        }
+
+        [Fact]
+        public void SaveAndLoad_RunAtStartup_PersistsCorrectly()
+        {
+            // Arrange
+            var service1 = new SettingsService(_testFilePath);
+            service1.Settings.RunAtStartup = true;
+
+            // Act
+            service1.SaveSettings();
+            var service2 = new SettingsService(_testFilePath);
+
+            // Assert
+            Assert.True(service2.Settings.RunAtStartup);
+        }
+
+        [Fact]
+        public void Load_DefaultSettings_HasEmptyAppAliases()
+        {
+            // Arrange & Act
+            var service = new SettingsService(_testFilePath);
+
+            // Assert
+            Assert.NotNull(service.Settings.AppAliases);
+            Assert.Empty(service.Settings.AppAliases);
+        }
+
+        [Fact]
+        public void Load_DefaultSettings_RunAtStartupIsFalse()
+        {
+            // Arrange & Act
+            var service = new SettingsService(_testFilePath);
+
+            // Assert
+            Assert.False(service.Settings.RunAtStartup);
+        }
     }
 }

--- a/tests/SoundBar.Tests/TimeSpanConverterTests.cs
+++ b/tests/SoundBar.Tests/TimeSpanConverterTests.cs
@@ -1,0 +1,56 @@
+using System;
+using SoundBar.Helpers;
+using Xunit;
+
+namespace SoundBar.Tests
+{
+    public class TimeSpanConverterTests
+    {
+        private readonly TimeSpanConverter _converter = new();
+
+        [Fact]
+        public void Convert_ZeroSeconds_ReturnsZeroColon00()
+        {
+            var result = _converter.Convert(0.0, typeof(string), null!, "en");
+            Assert.Equal("0:00", result);
+        }
+
+        [Fact]
+        public void Convert_65Seconds_Returns1Colon05()
+        {
+            var result = _converter.Convert(65.0, typeof(string), null!, "en");
+            Assert.Equal("1:05", result);
+        }
+
+        [Fact]
+        public void Convert_3661Seconds_Returns1Colon01Colon01()
+        {
+            // 1 hour, 1 minute, 1 second — should use h:mm:ss format
+            var result = _converter.Convert(3661.0, typeof(string), null!, "en");
+            Assert.Equal("1:01:01", result);
+        }
+
+        [Fact]
+        public void Convert_3599Seconds_Returns59Colon59()
+        {
+            // Just under 1 hour — should still use m:ss format
+            var result = _converter.Convert(3599.0, typeof(string), null!, "en");
+            Assert.Equal("59:59", result);
+        }
+
+        [Fact]
+        public void Convert_3600Seconds_Returns1Colon00Colon00()
+        {
+            // Exactly 1 hour boundary — should switch to h:mm:ss
+            var result = _converter.Convert(3600.0, typeof(string), null!, "en");
+            Assert.Equal("1:00:00", result);
+        }
+
+        [Fact]
+        public void Convert_NonDouble_ReturnsValueUnchanged()
+        {
+            var result = _converter.Convert("not a number", typeof(string), null!, "en");
+            Assert.Equal("not a number", result);
+        }
+    }
+}

--- a/tests/SoundBar.Tests/UpdateServiceTests.cs
+++ b/tests/SoundBar.Tests/UpdateServiceTests.cs
@@ -32,9 +32,41 @@ namespace SoundBar.Tests
         }
 
         [Fact]
-        public async Task CheckForUpdatesAsync_WhenNewerVersionExists_ReturnsTrue()
+        public async Task CheckForUpdatesAsync_WhenNewerVersionExists_WithBothAssets_ReturnsTrue()
         {
-            // Arrange
+            // Arrange — must include both .zip AND .sig assets to pass validation
+            string json = @"{
+                ""tag_name"": ""v9.9.9"",
+                ""assets"": [
+                    {
+                        ""name"": ""SoundBar-v9.9.9.zip"",
+                        ""browser_download_url"": ""https://github.com/test/download.zip""
+                    },
+                    {
+                        ""name"": ""SoundBar-v9.9.9.sig"",
+                        ""browser_download_url"": ""https://github.com/test/download.sig""
+                    }
+                ]
+            }";
+            
+            var handler = CreateMockMessageHandler(json, HttpStatusCode.OK);
+            UpdateService.SetTestMessageHandler(handler);
+            var service = new UpdateService();
+
+            // Act
+            bool result = await service.CheckForUpdatesAsync();
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("v9.9.9", service.LatestVersion);
+            Assert.Equal("https://github.com/test/download.zip", service.DownloadUrl);
+            Assert.Equal("https://github.com/test/download.sig", service.SignatureUrl);
+        }
+
+        [Fact]
+        public async Task CheckForUpdatesAsync_WhenNewerVersionExists_MissingSigAsset_ReturnsFalse()
+        {
+            // Arrange — only .zip asset, no .sig
             string json = @"{
                 ""tag_name"": ""v9.9.9"",
                 ""assets"": [
@@ -52,28 +84,28 @@ namespace SoundBar.Tests
             // Act
             bool result = await service.CheckForUpdatesAsync();
 
-            // Assert
-            Assert.True(result);
-            Assert.Equal("v9.9.9", service.LatestVersion);
-            Assert.Equal("https://github.com/test/download.zip", service.DownloadUrl);
+            // Assert — should refuse to update without a signature file
+            Assert.False(result);
         }
 
         [Fact]
         public async Task CheckForUpdatesAsync_WhenSameVersionExists_ReturnsFalse()
         {
-            // Arrange
-            // Using CurrentVersion to simulate no update
+            // Arrange — use the actual current version string
             string currentVersion = UpdateService.CurrentVersion;
-            string json = $@"""tag_name"": ""{currentVersion}"",
+            string json = $@"{{
+                ""tag_name"": ""{currentVersion}"",
                 ""assets"": [
                     {{
                         ""name"": ""SoundBar-{currentVersion}.zip"",
                         ""browser_download_url"": ""https://github.com/test/download.zip""
+                    }},
+                    {{
+                        ""name"": ""SoundBar-{currentVersion}.sig"",
+                        ""browser_download_url"": ""https://github.com/test/download.sig""
                     }}
                 ]
             }}";
-            // Fix json structure
-            json = "{" + json;
             
             var handler = CreateMockMessageHandler(json, HttpStatusCode.OK);
             UpdateService.SetTestMessageHandler(handler);


### PR DESCRIPTION
**Title:** Feature: v2.4.0 Theming, Nicknames, and Stability Overhaul
**Description:**
This introduces the massive v2.4.0 update, bringing requested customisation features and a significant stability pass to SoundBar.

**Key Additions:**
* **Native Theming:** Full support for Windows 11 Light and Dark themes, seamlessly swapping control colours. The background dimming overlay now intelligently shifts its frost effect to maintain text legibility.
* **App Nicknames:** Users can now click on an app's name in the mixer to type a custom alias (e.g. rename 'msedge' to 'Browser').
* **Compact Update Icon:** The large update banner has been replaced by a sleek, Discord-style green download icon in the title bar.
* **Global Versioning:** The current app version is now subtly displayed in the settings panel.

**Fixes & Optimisations:**
* Fixed a frustrating media control bug where slow scrubbing on the timeline would cause the slider to jump back without skipping the track.
* Completed a thorough memory sweep, ensuring UI bindings and event handlers remain leak-free.
* Added extensive XML documentation (in casual British English) to all core files, views, and viewmodels to assist future contributors.
