### PR TITLE
feat: add global volume hotkeys and release notes link (v2.5.0)

### DIFF
--- a/src/SoundBar/Helpers/WindowHelper.cs
+++ b/src/SoundBar/Helpers/WindowHelper.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SoundBar.Helpers
+{
+    /// <summary>
+    /// Provides helper methods to interact with Win32 Window APIs.
+    /// Used primarily to detect which app the user is currently focused on.
+    /// </summary>
+    public static class WindowHelper
+    {
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern int GetWindowTextLength(IntPtr hWnd);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        /// <summary>
+        /// Gets the Process ID of the application that currently has user focus.
+        /// </summary>
+        /// <returns>The Process ID, or 0 if it could not be determined.</returns>
+        public static uint GetForegroundProcessId()
+        {
+            IntPtr hWnd = GetForegroundWindow();
+            if (hWnd == IntPtr.Zero)
+            {
+                return 0;
+            }
+
+            GetWindowThreadProcessId(hWnd, out uint processId);
+            return processId;
+        }
+
+        /// <summary>
+        /// Gets the title of the currently focused window.
+        /// </summary>
+        public static string GetForegroundWindowTitle()
+        {
+            IntPtr hWnd = GetForegroundWindow();
+            if (hWnd == IntPtr.Zero)
+                return string.Empty;
+
+            int length = GetWindowTextLength(hWnd);
+            if (length == 0)
+                return string.Empty;
+
+            StringBuilder sb = new StringBuilder(length + 1);
+            GetWindowText(hWnd, sb, sb.Capacity);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/SoundBar/Models/AppSettings.cs
+++ b/src/SoundBar/Models/AppSettings.cs
@@ -61,6 +61,21 @@ namespace SoundBar.Models
         /// The visual theme of the application (Light, Dark, or System).
         /// </summary>
         public AppTheme Theme { get; set; } = AppTheme.System;
+
+        /// <summary>
+        /// Hotkey configuration string for increasing the focused app's volume. Format: "Ctrl+Alt+Up"
+        /// </summary>
+        public string VolumeUpHotkey { get; set; } = "Control+Alt+Up";
+
+        /// <summary>
+        /// Hotkey configuration string for decreasing the focused app's volume. Format: "Ctrl+Alt+Down"
+        /// </summary>
+        public string VolumeDownHotkey { get; set; } = "Control+Alt+Down";
+
+        /// <summary>
+        /// Hotkey configuration string for muting/unmuting the focused app. Format: "Ctrl+Alt+M"
+        /// </summary>
+        public string MuteHotkey { get; set; } = "Control+Alt+M";
     }
 
     /// <summary>

--- a/src/SoundBar/Services/HotkeyService.cs
+++ b/src/SoundBar/Services/HotkeyService.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Windows.System;
+
+namespace SoundBar.Services
+{
+    [Flags]
+    public enum HotkeyModifiers
+    {
+        None = 0,
+        Control = 1,
+        Alt = 2,
+        Shift = 4
+    }
+
+    public class HotkeyEventArgs : EventArgs
+    {
+        public VirtualKey Key { get; }
+        public HotkeyModifiers Modifiers { get; }
+        public bool Handled { get; set; }
+
+        public HotkeyEventArgs(VirtualKey key, HotkeyModifiers modifiers)
+        {
+            Key = key;
+            Modifiers = modifiers;
+            Handled = false;
+        }
+    }
+
+    /// <summary>
+    /// Implements a global low-level keyboard hook to listen for hotkeys even when the app is in the background.
+    /// </summary>
+    public class HotkeyService : IDisposable
+    {
+        private const int WH_KEYBOARD_LL = 13;
+        private const int WM_KEYDOWN = 0x0100;
+        private const int WM_SYSKEYDOWN = 0x0104;
+
+        private LowLevelKeyboardProc _proc;
+        private IntPtr _hookID = IntPtr.Zero;
+
+        public event EventHandler<HotkeyEventArgs>? KeyPressed;
+
+        public HotkeyService()
+        {
+            _proc = HookCallback;
+            _hookID = SetHook(_proc);
+        }
+
+        private IntPtr SetHook(LowLevelKeyboardProc proc)
+        {
+            try
+            {
+                IntPtr hInstance = Marshal.GetHINSTANCE(typeof(HotkeyService).Module);
+                return SetWindowsHookEx(WH_KEYBOARD_LL, proc, hInstance, 0);
+            }
+            catch
+            {
+                return IntPtr.Zero;
+            }
+        }
+
+        private delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+        private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode >= 0 && (wParam == (IntPtr)WM_KEYDOWN || wParam == (IntPtr)WM_SYSKEYDOWN))
+            {
+                int vkCode = Marshal.ReadInt32(lParam);
+                VirtualKey key = (VirtualKey)vkCode;
+
+                // Don't raise events for modifier keys themselves to avoid noise
+                if (key != VirtualKey.Control && key != VirtualKey.LeftControl && key != VirtualKey.RightControl &&
+                    key != VirtualKey.Menu && key != VirtualKey.LeftMenu && key != VirtualKey.RightMenu &&
+                    key != VirtualKey.Shift && key != VirtualKey.LeftShift && key != VirtualKey.RightShift)
+                {
+                    var args = new HotkeyEventArgs(key, GetModifiers());
+                    KeyPressed?.Invoke(this, args);
+
+                    if (args.Handled)
+                    {
+                        return (IntPtr)1; // Suppress the key
+                    }
+                }
+            }
+
+            return CallNextHookEx(_hookID, nCode, wParam, lParam);
+        }
+
+        private HotkeyModifiers GetModifiers()
+        {
+            HotkeyModifiers mods = HotkeyModifiers.None;
+            if ((GetAsyncKeyState(0x11) & 0x8000) != 0) mods |= HotkeyModifiers.Control; // VK_CONTROL
+            if ((GetAsyncKeyState(0x12) & 0x8000) != 0) mods |= HotkeyModifiers.Alt; // VK_MENU
+            if ((GetAsyncKeyState(0x10) & 0x8000) != 0) mods |= HotkeyModifiers.Shift; // VK_SHIFT
+            return mods;
+        }
+
+        public void Dispose()
+        {
+            if (_hookID != IntPtr.Zero)
+            {
+                UnhookWindowsHookEx(_hookID);
+                _hookID = IntPtr.Zero;
+            }
+            GC.KeepAlive(_proc);
+        }
+
+        // --- P/Invoke Definitions ---
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+    }
+}

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v2.4.1";
+        public const string CurrentVersion = "v2.5.0";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ namespace SoundBar.ViewModels
         private readonly SettingsService _settingsService;
         private readonly UpdateService _updateService;
         private readonly MediaInfoService _mediaInfoService;
+        private readonly HotkeyService _hotkeyService;
 
         /// <summary>
         /// A list of application executable names that the user prefers to keep out of sight.
@@ -375,6 +376,8 @@ namespace SoundBar.ViewModels
             _settingsService = settingsService;
             _updateService = new UpdateService();
             _mediaInfoService = new MediaInfoService();
+            _hotkeyService = new HotkeyService();
+            _hotkeyService.KeyPressed += HotkeyService_KeyPressed;
             _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
             // Connect to audio service
@@ -414,6 +417,89 @@ namespace SoundBar.ViewModels
 
             // Check for updates
             CheckForUpdatesAsync();
+        }
+
+        private void HotkeyService_KeyPressed(object? sender, HotkeyEventArgs e)
+        {
+            _dispatcherQueue.TryEnqueue(() =>
+            {
+                string pressedString = ParseHotkeyToString(e.Key, e.Modifiers);
+
+                uint activePid = WindowHelper.GetForegroundProcessId();
+                if (activePid == 0) return;
+
+                // Find the app in our collection that matches the foreground window's PID
+                var activeApp = Apps.FirstOrDefault(a => a.ProcessId == activePid);
+                if (activeApp == null) return;
+
+                if (pressedString == VolumeUpHotkey)
+                {
+                    activeApp.VolumePercentage = Math.Min(100, activeApp.VolumePercentage + 5);
+                    e.Handled = true;
+                }
+                else if (pressedString == VolumeDownHotkey)
+                {
+                    activeApp.VolumePercentage = Math.Max(0, activeApp.VolumePercentage - 5);
+                    e.Handled = true;
+                }
+                else if (pressedString == MuteHotkey)
+                {
+                    activeApp.IsMuted = !activeApp.IsMuted;
+                    e.Handled = true;
+                }
+            });
+        }
+
+        private string ParseHotkeyToString(Windows.System.VirtualKey key, HotkeyModifiers modifiers)
+        {
+            string modStr = "";
+            if (modifiers.HasFlag(HotkeyModifiers.Control)) modStr += "Control+";
+            if (modifiers.HasFlag(HotkeyModifiers.Alt)) modStr += "Alt+";
+            if (modifiers.HasFlag(HotkeyModifiers.Shift)) modStr += "Shift+";
+
+            return modStr + key.ToString();
+        }
+
+        public string VolumeUpHotkey
+        {
+            get => _settingsService.Settings.VolumeUpHotkey;
+            set
+            {
+                if (_settingsService.Settings.VolumeUpHotkey != value)
+                {
+                    _settingsService.Settings.VolumeUpHotkey = value;
+                    _settingsService.SaveSettings();
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string VolumeDownHotkey
+        {
+            get => _settingsService.Settings.VolumeDownHotkey;
+            set
+            {
+                if (_settingsService.Settings.VolumeDownHotkey != value)
+                {
+                    _settingsService.Settings.VolumeDownHotkey = value;
+                    _settingsService.SaveSettings();
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string MuteHotkey
+        {
+            get => _settingsService.Settings.MuteHotkey;
+            set
+            {
+                if (_settingsService.Settings.MuteHotkey != value)
+                {
+                    _settingsService.Settings.MuteHotkey = value;
+                    _settingsService.SaveSettings();
+                    OnPropertyChanged();
+                }
+            }
         }
 
         private async void CheckForUpdatesAsync()
@@ -1210,6 +1296,23 @@ namespace SoundBar.ViewModels
             }
         }
 
+        public void OpenReleaseNotes()
+        {
+            try
+            {
+                var processInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = $"https://github.com/levon2805/SoundBar/releases/tag/{UpdateService.CurrentVersion}",
+                    UseShellExecute = true
+                };
+                System.Diagnostics.Process.Start(processInfo);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to open release notes: {ex.Message}");
+            }
+        }
+
         public void Dispose()
         {
             _pollingCts?.Cancel();
@@ -1219,6 +1322,7 @@ namespace SoundBar.ViewModels
             _progressTimer?.Stop();
 
             _mediaInfoService?.Dispose();
+            _hotkeyService?.Dispose();
 
             // Dispose all AudioAppModels to cancel any in-flight debounce tasks
             foreach (var app in Apps)

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -35,11 +35,26 @@ namespace SoundBar.Views
         /// </summary>
         public MainWindow()
         {
-            this.InitializeComponent();
+            try
+            {
+                this.InitializeComponent();
 
-            _settingsService = new SettingsService();
-            ViewModel = new MainViewModel(_settingsService);
-            ((FrameworkElement)this.Content).DataContext = ViewModel;
+                _settingsService = new SettingsService();
+                ViewModel = new MainViewModel(_settingsService);
+                ((FrameworkElement)this.Content).DataContext = ViewModel;
+
+                // We dynamically build the UI here because the local machine's XAML compiler
+                // is throwing MSB4062 and failing to compile new XAML nodes correctly.
+                BuildDynamicUI();
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                var localFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                System.IO.File.WriteAllText(System.IO.Path.Combine(localFolder, "soundbar_crash_log.txt"), ex.ToString());
+#endif
+                throw;
+            }
 
             // Apply initial theme and listen for changes
             ApplyTheme(ViewModel.SelectedTheme);
@@ -428,6 +443,111 @@ namespace SoundBar.Views
                 // Force focus back to the main content grid to trigger LostFocus binding update
                 MainContentGrid.Focus(FocusState.Programmatic);
                 e.Handled = true;
+            }
+        }
+
+        private void VersionHyperlink_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.OpenReleaseNotes();
+        }
+
+        private void BuildDynamicUI()
+        {
+            try
+            {
+                // Traverse the visual tree to find all ScrollViewers
+                var scrollViewers = new System.Collections.Generic.List<ScrollViewer>();
+                FindVisualChildren(this.Content, scrollViewers);
+                
+                // The settings ScrollViewer is the one containing a StackPanel
+                StackPanel settingsPanel = null;
+                
+                foreach (var sv in scrollViewers)
+                {
+                    if (sv.Content is StackPanel sp)
+                    {
+                        settingsPanel = sp;
+                        break;
+                    }
+                }
+
+                if (settingsPanel == null) return;
+
+                // 1. About & Updates Expander (Top)
+                var aboutExpander = new Expander
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    Header = new TextBlock { Text = "About & Updates", FontSize = 14, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold }
+                };
+                
+                var aboutStack = new StackPanel { Spacing = 15 };
+                aboutStack.Children.Add(new TextBlock { Text = "Check out the latest features and changes in this version.", FontSize = 12, TextWrapping = TextWrapping.Wrap });
+                var releaseNotesBtn = new Button { Content = "View Release Notes" };
+                releaseNotesBtn.Click += VersionHyperlink_Click;
+                aboutStack.Children.Add(releaseNotesBtn);
+                aboutExpander.Content = aboutStack;
+                
+                // Insert at the very top
+                settingsPanel.Children.Insert(0, aboutExpander);
+
+                // 2. Global Hotkeys Expander
+                var keybindsExpander = new Expander
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    Header = new TextBlock { Text = "Global Hotkeys", FontSize = 14, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold }
+                };
+                
+                var keybindsStack = new StackPanel { Spacing = 15 };
+                keybindsStack.Children.Add(new TextBlock { Text = "Control the volume of the app you are currently using without leaving it.", FontSize = 12, TextWrapping = TextWrapping.Wrap });
+                
+                // Volume Up
+                var volUpStack = new StackPanel();
+                volUpStack.Children.Add(new TextBlock { Text = "Volume Up Hotkey", Margin = new Thickness(0, 0, 0, 5) });
+                var volUpBox = new TextBox { PlaceholderText = "e.g. Control+Alt+Up" };
+                volUpBox.SetBinding(TextBox.TextProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath("VolumeUpHotkey"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+                volUpStack.Children.Add(volUpBox);
+                keybindsStack.Children.Add(volUpStack);
+                
+                // Volume Down
+                var volDownStack = new StackPanel();
+                volDownStack.Children.Add(new TextBlock { Text = "Volume Down Hotkey", Margin = new Thickness(0, 0, 0, 5) });
+                var volDownBox = new TextBox { PlaceholderText = "e.g. Control+Alt+Down" };
+                volDownBox.SetBinding(TextBox.TextProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath("VolumeDownHotkey"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+                volDownStack.Children.Add(volDownBox);
+                keybindsStack.Children.Add(volDownStack);
+                
+                // Mute
+                var muteStack = new StackPanel();
+                muteStack.Children.Add(new TextBlock { Text = "Mute Hotkey", Margin = new Thickness(0, 0, 0, 5) });
+                var muteBox = new TextBox { PlaceholderText = "e.g. Control+Alt+M" };
+                muteBox.SetBinding(TextBox.TextProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath("MuteHotkey"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+                muteStack.Children.Add(muteBox);
+                keybindsStack.Children.Add(muteStack);
+                
+                keybindsExpander.Content = keybindsStack;
+                
+                // Insert right before System Integration Settings (which is the last item)
+                int insertIndex = Math.Max(0, settingsPanel.Children.Count - 1);
+                settingsPanel.Children.Insert(insertIndex, keybindsExpander);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Failed to build dynamic UI: {ex.Message}");
+            }
+        }
+
+        private void FindVisualChildren<T>(DependencyObject parent, System.Collections.Generic.List<T> results) where T : DependencyObject
+        {
+            for (int i = 0; i < Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetChild(parent, i);
+                if (child is T t)
+                {
+                    results.Add(t);
+                }
+                FindVisualChildren(child, results);
             }
         }
     }


### PR DESCRIPTION
- Implemented `HotkeyService` using low-level keyboard hooks (`SetWindowsHookEx`) to allow volume control while the app is in the background.
- Added `VolumeUpHotkey`, `VolumeDownHotkey`, and `MuteHotkey` configurations to `AppSettings` (defaults to Control+Alt+Up/Down/M).
- Added logic in `MainViewModel` to adjust the volume of the currently focused application (`WindowHelper.GetForegroundProcessId()`).
- Added "View Release Notes" button linking directly to the current version's GitHub release page.
- Implemented `BuildDynamicUI()` in `MainWindow.xaml.cs` to inject new UI elements programmatically, bypassing the local `MSB4062` XAML compiler build error.
- Bumped `CurrentVersion` to `v2.5.0`.