### PR TITLE
Hotfix: Reorganise Settings Menu UI and De-clutter Top Bar (v2.5.2)

### DIFF
--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v2.5.1";
+        public const string CurrentVersion = "v2.5.2";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -46,6 +46,9 @@ namespace SoundBar.Views
                 // We dynamically build the UI here because the local machine's XAML compiler
                 // is throwing MSB4062 and failing to compile new XAML nodes correctly.
                 BuildDynamicUI();
+
+                // Hide the top-bar DND button since we moved it into settings
+                DndToggleButton.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
             }
             catch (Exception ex)
             {
@@ -485,9 +488,6 @@ namespace SoundBar.Views
                 aboutStack.Children.Add(releaseNotesBtn);
                 aboutExpander.Content = aboutStack;
                 
-                // Insert at the very top
-                settingsPanel.Children.Insert(0, aboutExpander);
-
                 // 2. Global Hotkeys Expander
                 var keybindsExpander = new Expander
                 {
@@ -525,9 +525,78 @@ namespace SoundBar.Views
                 
                 keybindsExpander.Content = keybindsStack;
                 
-                // Insert right before System Integration Settings (which is the last item)
-                int insertIndex = Math.Max(0, settingsPanel.Children.Count - 1);
-                settingsPanel.Children.Insert(insertIndex, keybindsExpander);
+                // 3. Do Not Disturb Expander
+                var dndExpander = new Expander
+                {
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                    Header = new TextBlock { Text = "Do Not Disturb Mode", FontSize = 14, FontWeight = Microsoft.UI.Text.FontWeights.SemiBold }
+                };
+                
+                var dndStack = new StackPanel { Spacing = 15 };
+                dndStack.Children.Add(new TextBlock { Text = "Mutes all system sounds and notifications when enabled.", FontSize = 12, TextWrapping = TextWrapping.Wrap });
+                var dndToggle = new ToggleSwitch { OnContent = "Enabled", OffContent = "Disabled" };
+                dndToggle.SetBinding(ToggleSwitch.IsOnProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath("IsDoNotDisturbEnabled"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+                
+                // Keep the icon color logic synced if they toggle from settings menu
+                dndToggle.Toggled += DndToggleButton_Changed;
+                
+                dndStack.Children.Add(dndToggle);
+                dndExpander.Content = dndStack;
+                
+                // Collect existing Expanders
+                var expanders = new System.Collections.Generic.Dictionary<string, Expander>();
+                foreach (var child in settingsPanel.Children)
+                {
+                    if (child is Expander exp && exp.Header is TextBlock header)
+                    {
+                        expanders[header.Text] = exp;
+                    }
+                }
+                
+                // Clear the panel to rebuild it in order
+                settingsPanel.Children.Clear();
+                
+                // Helper to add group headers
+                void AddCategoryHeader(string title, bool isFirst = false)
+                {
+                    settingsPanel.Children.Add(new TextBlock 
+                    { 
+                        Text = title, 
+                        FontSize = 16, 
+                        FontWeight = Microsoft.UI.Text.FontWeights.Bold, 
+                        Margin = new Thickness(0, isFirst ? 0 : 20, 0, 5) 
+                    });
+                }
+
+                // Helper to add expander if it exists
+                void AddExpander(string key, Expander explicitExpander = null)
+                {
+                    if (explicitExpander != null)
+                        settingsPanel.Children.Add(explicitExpander);
+                    else if (expanders.TryGetValue(key, out var exp))
+                        settingsPanel.Children.Add(exp);
+                }
+
+                // --- Build New Ordered UI ---
+
+                AddCategoryHeader("Personalisation", true);
+                AddExpander("Appearance");
+                AddExpander("Custom Background");
+
+                AddCategoryHeader("Audio & Focus");
+                AddExpander("Global Hotkeys", keybindsExpander);
+                AddExpander("Do Not Disturb Mode", dndExpander);
+                AddExpander("Hearing Protection");
+                AddExpander("Media Controls");
+
+                AddCategoryHeader("App Management");
+                AddExpander("Hidden Apps");
+                AddExpander("Background Apps");
+
+                AddCategoryHeader("General");
+                AddExpander("System Integration");
+                AddExpander("About & Updates", aboutExpander);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Overview
This PR addresses UI clutter and improves the navigability of the Settings menu. It groups settings into logical categories, enforces British English spelling, and moves the Do Not Disturb toggle out of the top navigation bar to free up space.

## Key Changes
- **Do Not Disturb Relocated:** The `DndToggleButton` is now hidden (`Visibility.Collapsed`) from the main window. It has been re-implemented as a dynamically injected `Expander` inside the Settings menu.
- **Categorisation:** Settings are now grouped into four distinct categories with clear visual separation:
  1. **Personalisation** (Appearance, Custom Background)
  2. **Audio & Focus** (Global Hotkeys, Do Not Disturb Mode, Hearing Protection, Media Controls)
  3. **App Management** (Hidden Apps, Background Apps)
  4. **General** (System Integration, About & Updates)

- **Dynamic UI Injection:** To avoid tripping the `MSB4062` `ExpandPriContent` XAML compiler bug present in the local environment, all reorganisations and new UI additions are performed in C# code-behind via `BuildDynamicUI()`.
- Bumped version to `v2.5.2`.
