### PR TITLE
v2.5.3 QOL Patch

### DIFF
--- a/src/SoundBar/Models/AppSettings.cs
+++ b/src/SoundBar/Models/AppSettings.cs
@@ -63,6 +63,11 @@ namespace SoundBar.Models
         public AppTheme Theme { get; set; } = AppTheme.System;
 
         /// <summary>
+        /// Whether to show a visual highlight outline around the currently focused application.
+        /// </summary>
+        public bool EnableFocusHighlight { get; set; } = true;
+
+        /// <summary>
         /// Hotkey configuration string for increasing the focused app's volume. Format: "Ctrl+Alt+Up"
         /// </summary>
         public string VolumeUpHotkey { get; set; } = "Control+Alt+Up";

--- a/src/SoundBar/Models/AudioAppModel.cs
+++ b/src/SoundBar/Models/AudioAppModel.cs
@@ -108,9 +108,12 @@ namespace SoundBar.Models
                     OnPropertyChanged(nameof(VolumePercentage));
 
                     // Cancel any pending volume changes so we don't spam the OS while sliding.
-                    _volumeDebounce?.Cancel();
+                    if (_volumeDebounce != null)
+                    {
+                        _volumeDebounce.Cancel();
+                        _volumeDebounce.Dispose();
+                    }
                     
-                    // We let the GC tidy up the old token source once the task finishes.
                     _volumeDebounce = new System.Threading.CancellationTokenSource();
                     var token = _volumeDebounce.Token;
                     var capturedVolume = _volume;
@@ -193,6 +196,23 @@ namespace SoundBar.Models
         /// True if this seems to be a sneaky background process without a proper window.
         /// </summary>
         public bool IsBackgroundApp { get; set; }
+
+        private bool _isFocused;
+        /// <summary>
+        /// True if this application is currently the active foreground window.
+        /// </summary>
+        public bool IsFocused
+        {
+            get => _isFocused;
+            set
+            {
+                if (_isFocused != value)
+                {
+                    _isFocused = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         /// <summary>
         /// Lets us know if the Windows Audio Session is still breathing.

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v2.5.2";
+        public const string CurrentVersion = "v2.5.3";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/Services/WindowsAudioMixerService.cs
+++ b/src/SoundBar/Services/WindowsAudioMixerService.cs
@@ -100,9 +100,6 @@ namespace SoundBar.Services
                                 displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
                             }
 
-                            // If we already have a slider for this display name, skip it
-                            if (addedNames.Contains(displayName)) continue;
-
                             bool isBackground = true;
                             string? safeIconPath = null;
 
@@ -147,8 +144,13 @@ namespace SoundBar.Services
 
                             safeIconPath = GetExecutablePathSafely(process);
 
-                            // Cache so we never run the slow path for this ProcessId again
+                            // Cache so we never run the slow path for this ProcessId again.
+                            // We MUST do this before the addedNames check so secondary sessions get cached 
+                            // and can respond to volume/mute commands!
                             _processCache[processId] = (displayName, processName, isBackground, safeIconPath);
+
+                            // If we already have a slider for this display name, skip adding it to the UI list
+                            if (addedNames.Contains(displayName)) continue;
 
                             sessions.Add(new AudioSessionData
                             {

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -251,6 +251,20 @@ namespace SoundBar.ViewModels
             _isLoudnessWarningDismissed = true;
         }
 
+        public bool EnableFocusHighlight
+        {
+            get => _settingsService.Settings.EnableFocusHighlight;
+            set
+            {
+                if (_settingsService.Settings.EnableFocusHighlight != value)
+                {
+                    _settingsService.Settings.EnableFocusHighlight = value;
+                    OnPropertyChanged();
+                    _settingsService.SaveSettings();
+                }
+            }
+        }
+
         // Timestamp for Master Volume
         private DateTime _lastMasterVolumeChange = DateTime.MinValue;
         private System.Threading.CancellationTokenSource? _masterVolumeDebounce;
@@ -312,14 +326,17 @@ namespace SoundBar.ViewModels
 
                 if (enable)
                 {
-                    Type wshShellType = Type.GetTypeFromProgID("WScript.Shell");
+                    Type? wshShellType = Type.GetTypeFromProgID("WScript.Shell");
                     if (wshShellType != null)
                     {
-                        dynamic shell = Activator.CreateInstance(wshShellType);
-                        dynamic shortcut = shell.CreateShortcut(shortcutPath);
-                        shortcut.TargetPath = System.Environment.ProcessPath;
-                        shortcut.WorkingDirectory = AppContext.BaseDirectory;
-                        shortcut.Save();
+                        dynamic? shell = Activator.CreateInstance(wshShellType);
+                        if (shell != null)
+                        {
+                            dynamic shortcut = shell.CreateShortcut(shortcutPath);
+                            shortcut.TargetPath = System.Environment.ProcessPath;
+                            shortcut.WorkingDirectory = AppContext.BaseDirectory;
+                            shortcut.Save();
+                        }
                     }
                 }
                 else
@@ -448,27 +465,26 @@ namespace SoundBar.ViewModels
             {
                 string pressedString = ParseHotkeyToString(e.Key, e.Modifiers);
 
-                uint activePid = WindowHelper.GetForegroundProcessId();
-                if (activePid == 0) return;
+                var activeApps = Apps.Where(a => a.IsFocused).ToList();
+                if (!activeApps.Any()) return;
 
-                // Find the app in our collection that matches the foreground window's PID
-                var activeApp = Apps.FirstOrDefault(a => a.ProcessId == activePid);
-                if (activeApp == null) return;
-
-                if (pressedString == VolumeUpHotkey)
+                foreach (var activeApp in activeApps)
                 {
-                    activeApp.VolumePercentage = Math.Min(100, activeApp.VolumePercentage + 5);
-                    e.Handled = true;
-                }
-                else if (pressedString == VolumeDownHotkey)
-                {
-                    activeApp.VolumePercentage = Math.Max(0, activeApp.VolumePercentage - 5);
-                    e.Handled = true;
-                }
-                else if (pressedString == MuteHotkey)
-                {
-                    activeApp.IsMuted = !activeApp.IsMuted;
-                    e.Handled = true;
+                    if (pressedString == VolumeUpHotkey)
+                    {
+                        activeApp.VolumePercentage = Math.Min(100, activeApp.VolumePercentage + 5);
+                        e.Handled = true;
+                    }
+                    else if (pressedString == VolumeDownHotkey)
+                    {
+                        activeApp.VolumePercentage = Math.Max(0, activeApp.VolumePercentage - 5);
+                        e.Handled = true;
+                    }
+                    else if (pressedString == MuteHotkey)
+                    {
+                        activeApp.IsMuted = !activeApp.IsMuted;
+                        e.Handled = true;
+                    }
                 }
             });
         }
@@ -717,6 +733,43 @@ namespace SoundBar.ViewModels
 
                             // Sync Audio Devices
                             UpdateAudioDevices(audioDevices);
+
+                            // Update Focus Outline (support multi-process apps like Discord)
+                            uint activePid = WindowHelper.GetForegroundProcessId();
+                            string activeProcessName = "";
+                            try
+                            {
+                                if (activePid > 0)
+                                {
+                                    var proc = System.Diagnostics.Process.GetProcessById((int)activePid);
+                                    activeProcessName = proc.ProcessName;
+                                }
+                            }
+                            catch { }
+
+                            foreach (var app in Apps)
+                            {
+                                bool isMatch = false;
+                                if (activePid > 0)
+                                {
+                                    if (app.ProcessId == activePid)
+                                    {
+                                        isMatch = true;
+                                    }
+                                    else if (!string.IsNullOrEmpty(activeProcessName) && !string.IsNullOrEmpty(app.RawProcessName))
+                                    {
+                                        string rawNoExt = app.RawProcessName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) 
+                                            ? app.RawProcessName.Substring(0, app.RawProcessName.Length - 4) 
+                                            : app.RawProcessName;
+                                            
+                                        if (rawNoExt.Equals(activeProcessName, StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            isMatch = true;
+                                        }
+                                    }
+                                }
+                                app.IsFocused = isMatch;
+                            }
                         });
                     }
                     catch (System.Exception)
@@ -1298,19 +1351,22 @@ namespace SoundBar.ViewModels
         {
             try
             {
-                Type wshShellType = Type.GetTypeFromProgID("WScript.Shell");
+                Type? wshShellType = Type.GetTypeFromProgID("WScript.Shell");
                 if (wshShellType != null)
                 {
-                    dynamic shell = Activator.CreateInstance(wshShellType);
-                    string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-                    string shortcutPath = System.IO.Path.Combine(desktopPath, "SoundBar.lnk");
-                    
-                    dynamic shortcut = shell.CreateShortcut(shortcutPath);
-                    shortcut.TargetPath = Environment.ProcessPath;
+                    dynamic? shell = Activator.CreateInstance(wshShellType);
+                    if (shell != null)
+                    {
+                        string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+                        string shortcutPath = System.IO.Path.Combine(desktopPath, "SoundBar.lnk");
+                        
+                        dynamic shortcut = shell.CreateShortcut(shortcutPath);
+                        shortcut.TargetPath = Environment.ProcessPath;
                     shortcut.WorkingDirectory = System.IO.Path.GetDirectoryName(Environment.ProcessPath);
-                    shortcut.Description = "SoundBar Audio Mixer";
-                    shortcut.IconLocation = System.IO.Path.Combine(AppContext.BaseDirectory, "Assets", "SoundBar.ico");
-                    shortcut.Save();
+                        shortcut.Description = "SoundBar Audio Mixer";
+                        shortcut.IconLocation = System.IO.Path.Combine(AppContext.BaseDirectory, "Assets", "SoundBar.ico");
+                        shortcut.Save();
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -455,7 +455,13 @@
                                           Background="{ThemeResource ControlFillColorDefaultBrush}"
                                           BorderThickness="1"
                                           BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}" 
+                                          Margin="0,0,0,15"/>
+
+                                <TextBlock Text="Highlights the active application so you know which volume you are controlling via hotkeys." Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"/>
+                                <ToggleSwitch Header="Active App Highlight" 
+                                              IsOn="{Binding EnableFocusHighlight, Mode=TwoWay}" 
+                                              Foreground="{ThemeResource TextFillColorPrimaryBrush}"/>
                             </StackPanel>
                         </Expander>
 

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -29,6 +29,8 @@ namespace SoundBar.Views
 
         private readonly SettingsService _settingsService;
         private AppWindow _appWindow;
+        private DispatcherTimer? _focusOutlineTimer;
+        private ItemsControl? _appsItemsControl;
 
         /// <summary>
         /// Sets up the window, wires up the ViewModel, and restores our saved settings.
@@ -63,6 +65,11 @@ namespace SoundBar.Views
             ApplyTheme(ViewModel.SelectedTheme);
             ViewModel.ThemeChanged += (s, theme) => ApplyTheme(theme);
 
+            // Start focus outline visual updater
+            _focusOutlineTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(250) };
+            _focusOutlineTimer.Tick += FocusOutlineTimer_Tick;
+            _focusOutlineTimer.Start();
+
             this.ExtendsContentIntoTitleBar = true;
             this.SetTitleBar(null);
 
@@ -85,6 +92,99 @@ namespace SoundBar.Views
             }
 
             RestoreWindowPosition();
+        }
+
+        private void FocusOutlineTimer_Tick(object? sender, object e)
+        {
+            if (ViewModel == null) return;
+
+            // Lazily find the ItemsControl because XAML bindings might not be evaluated immediately in the constructor
+            if (_appsItemsControl == null)
+            {
+                var itemsControls = new System.Collections.Generic.List<ItemsControl>();
+                FindVisualChildren(this.Content, itemsControls);
+                foreach (var ic in itemsControls)
+                {
+                    if (ic.ItemsSource == ViewModel.Apps)
+                    {
+                        _appsItemsControl = ic;
+                        break;
+                    }
+                }
+            }
+
+            if (_appsItemsControl == null) return;
+
+            foreach (var app in ViewModel.Apps)
+            {
+                var container = _appsItemsControl.ContainerFromItem(app) as DependencyObject;
+                if (container != null)
+                {
+                    // Find the main Grid inside the DataTemplate
+                    var grids = new System.Collections.Generic.List<Grid>();
+                    FindVisualChildren(container, grids);
+                    if (grids.Count > 0)
+                    {
+                        var rowGrid = grids[0];
+                        if (app.IsFocused && ViewModel.EnableFocusHighlight)
+                        {
+                            // A clearly visible, translucent blue accent
+                            rowGrid.Background = new SolidColorBrush(Windows.UI.Color.FromArgb(40, 0, 120, 215));
+                            rowGrid.CornerRadius = new CornerRadius(8);
+                        }
+                        else
+                        {
+                            rowGrid.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+                        }
+                        
+                        // Handle Mute Visualization
+                        var textBlocks = new System.Collections.Generic.List<TextBlock>();
+                        FindVisualChildren(rowGrid, textBlocks);
+                        foreach (var tb in textBlocks)
+                        {
+                            if (Grid.GetColumn(tb) == 3)
+                            {
+                                if (app.IsMuted)
+                                {
+                                    tb.Text = "\uE74F"; // Segoe Fluent VolumeMute icon
+                                    tb.FontFamily = new Microsoft.UI.Xaml.Media.FontFamily("Segoe Fluent Icons");
+                                    tb.Foreground = new SolidColorBrush(Microsoft.UI.Colors.Red);
+                                    tb.FontSize = 16;
+                                }
+                                else
+                                {
+                                    tb.Text = $"{app.VolumePercentage}%";
+                                    tb.ClearValue(TextBlock.FontFamilyProperty);
+                                    tb.ClearValue(TextBlock.ForegroundProperty);
+                                    tb.ClearValue(TextBlock.FontSizeProperty);
+                                }
+                            }
+                        }
+
+                        // Attach Mute/Unmute click handler to App Icon
+                        var images = new System.Collections.Generic.List<Image>();
+                        FindVisualChildren(rowGrid, images);
+                        if (images.Count > 0)
+                        {
+                            var img = images[0];
+                            // Always detach first to ensure we don't double-subscribe or subscribe to the wrong app model if containers are recycled
+                            img.Tapped -= AppIcon_Tapped;
+                            img.Tag = app;
+                            img.Tapped += AppIcon_Tapped;
+                            ToolTipService.SetToolTip(img, "Click to mute/unmute");
+                        }
+                    }
+                }
+            }
+        }
+
+        private void AppIcon_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            if (sender is Image img && img.Tag is AudioAppModel app)
+            {
+                app.IsMuted = !app.IsMuted;
+                e.Handled = true;
+            }
         }
 
         private void ApplyTheme(AppTheme theme)
@@ -460,13 +560,25 @@ namespace SoundBar.Views
                 FindVisualChildren(this.Content, scrollViewers);
                 
                 // The settings ScrollViewer is the one containing a StackPanel
-                StackPanel settingsPanel = null;
+                StackPanel? settingsPanel = null;
                 
                 foreach (var sv in scrollViewers)
                 {
                     if (sv.Content is StackPanel sp)
                     {
                         settingsPanel = sp;
+                        break;
+                    }
+                }
+
+                // Also find the ItemsControl that holds our Audio Apps
+                var itemsControls = new System.Collections.Generic.List<ItemsControl>();
+                FindVisualChildren(this.Content, itemsControls);
+                foreach (var ic in itemsControls)
+                {
+                    if (ic.ItemsSource == ViewModel.Apps)
+                    {
+                        _appsItemsControl = ic;
                         break;
                     }
                 }
@@ -570,7 +682,7 @@ namespace SoundBar.Views
                 }
 
                 // Helper to add expander if it exists
-                void AddExpander(string key, Expander explicitExpander = null)
+                void AddExpander(string key, Expander? explicitExpander = null)
                 {
                     if (explicitExpander != null)
                         settingsPanel.Children.Add(explicitExpander);
@@ -582,6 +694,38 @@ namespace SoundBar.Views
 
                 AddCategoryHeader("Personalisation", true);
                 AddExpander("Appearance");
+
+                // Dynamically inject the Active App Highlight toggle into the Appearance expander
+                // (Done in C# to bypass the MSB4062 XAML compiler error on the host machine)
+                if (expanders.TryGetValue("Appearance", out var appearanceExp) && appearanceExp.Content is StackPanel appearanceStack)
+                {
+                    // Check if it already has it to prevent duplicates on hot reloads
+                    bool hasHighlightSetting = false;
+                    foreach (var child in appearanceStack.Children)
+                    {
+                        if (child is ToggleSwitch ts && ts.Header?.ToString() == "Active App Highlight")
+                            hasHighlightSetting = true;
+                    }
+
+                    if (!hasHighlightSetting)
+                    {
+                        appearanceStack.Children.Add(new TextBlock 
+                        { 
+                            Text = "Highlights the active application so you know which volume you are controlling via hotkeys.", 
+                            FontSize = 12, 
+                            TextWrapping = TextWrapping.Wrap,
+                            Margin = new Thickness(0, 20, 0, 10) 
+                        });
+                        
+                        var highlightToggle = new ToggleSwitch { Header = "Active App Highlight" };
+                        highlightToggle.SetBinding(ToggleSwitch.IsOnProperty, new Microsoft.UI.Xaml.Data.Binding 
+                        { 
+                            Path = new PropertyPath("EnableFocusHighlight"), 
+                            Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay 
+                        });
+                        appearanceStack.Children.Add(highlightToggle);
+                    }
+                }
                 AddExpander("Custom Background");
 
                 AddCategoryHeader("Audio & Focus");


### PR DESCRIPTION
## Overview
This PR wraps up the `v2.5.3` quality-of-life and performance patch. It brings much-needed visual clarity to the global hotkey system and squashes a massive edge-case bug regarding multi-process applications.

## Key Changes
- **Active App Highlights:** Tabbing into a program now draws a clear blue highlight around its volume slider in SoundBar, so you instantly know which app your hotkeys will affect. This can be toggled off via the new `Active App Highlight` setting in the Appearance menu.
- **Click-to-Mute:** Users can now click directly on application icons to toggle their mute status, completely visually replacing the volume number with a red mute symbol for at-a-glance clarity.
- **The "Discord Bug" Fix:** Fixed `GetActiveAudioSessions()` prematurely skipping cache injection for secondary processes sharing a display name. Apps that spawn separate UI and hidden audio-handler `.exe`s (like Discord) will now correctly have all their underlying processes synced and volume-controlled simultaneously.
- **Deep Memory Sweep:** 
  - Verified stability of the `_processCache` cleanup cycle.
  - Resolved an unmanaged resource leak in `AudioAppModel` by correctly running `.Dispose()` on debounced `CancellationTokenSource`s.
  - Shielded injected XAML event handlers against WinUI container recycling.

## Testing Performed
- [x] Verified Discord and multi-process apps correctly track volume.
- [x] Verified rapid volume slider scrubbing does not throw `ObjectDisposedException`s or leak unmanaged handles.
- [x] Verified UI highlights accurately follow Windows foreground process hooks.
- [x] Verified `Active App Highlight` setting successfully updates and saves.
