### PR TITLE
fix: Resolve delayed-window app detection and prevent thread crashes

### DIFF
--- a/src/SoundBar/Services/IAudioMixerService.cs
+++ b/src/SoundBar/Services/IAudioMixerService.cs
@@ -69,5 +69,10 @@ namespace SoundBar.Services
         /// </summary>
         /// <param name="deviceId">The unique system identifier for the device.</param>
         void SetDefaultAudioDevice(string deviceId);
+
+        /// <summary>
+        /// Clears internal caches to force a full re-evaluation of audio sessions.
+        /// </summary>
+        void ClearCache();
     }
 }

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v2.5.3";
+        public const string CurrentVersion = "v2.5.4";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/Services/WindowsAudioMixerService.cs
+++ b/src/SoundBar/Services/WindowsAudioMixerService.cs
@@ -15,7 +15,8 @@ namespace SoundBar.Services
     internal class WindowsAudioMixerService : IAudioMixerService, IDisposable
     {
         // We keep a little cache of ProcessId -> App Info so we don't have to allocate heavy Process objects every single tick.
-        private readonly Dictionary<int, (string DisplayName, string RawProcessName, bool IsBackground, string? IconPath)> _processCache = new();
+        private readonly Dictionary<int, (string DisplayName, string RawProcessName, bool IsBackground, string? IconPath, DateTime LastChecked)> _processCache = new();
+        private readonly object _processCacheLock = new object();
 
         /// <summary>
         /// Rummages through Windows to find every app currently hooked into the audio system.
@@ -56,8 +57,28 @@ namespace SoundBar.Services
                             seenProcessIdsThisTick.Add(processId);
 
                             // FAST PATH: Use cached process info (most ticks hit this)
-                            if (_processCache.TryGetValue(processId, out var cachedApp))
+                            bool hitCache = false;
+                            (string DisplayName, string RawProcessName, bool IsBackground, string? IconPath, DateTime LastChecked) cachedApp = default;
+                            
+                            lock (_processCacheLock)
                             {
+                                hitCache = _processCache.TryGetValue(processId, out cachedApp);
+                            }
+
+                            if (hitCache)
+                            {
+                                // If it was previously a background app, it might have spawned a window now!
+                                // Re-evaluate every 5 seconds to catch games like Blue Prince that delay their window creation.
+                                if (cachedApp.IsBackground && (DateTime.Now - cachedApp.LastChecked).TotalSeconds > 5)
+                                {
+                                    bool stillBackground = CheckIfBackgroundProcess(cachedApp.RawProcessName);
+                                    lock (_processCacheLock)
+                                    {
+                                        _processCache[processId] = (cachedApp.DisplayName, cachedApp.RawProcessName, stillBackground, cachedApp.IconPath, DateTime.Now);
+                                    }
+                                    cachedApp.IsBackground = stillBackground; // update local tuple
+                                }
+
                                 if (addedNames.Contains(cachedApp.DisplayName)) continue;
 
                                 sessions.Add(new AudioSessionData
@@ -147,7 +168,10 @@ namespace SoundBar.Services
                             // Cache so we never run the slow path for this ProcessId again.
                             // We MUST do this before the addedNames check so secondary sessions get cached 
                             // and can respond to volume/mute commands!
-                            _processCache[processId] = (displayName, processName, isBackground, safeIconPath);
+                            lock (_processCacheLock)
+                            {
+                                _processCache[processId] = (displayName, processName, isBackground, safeIconPath, DateTime.Now);
+                            }
 
                             // If we already have a slider for this display name, skip adding it to the UI list
                             if (addedNames.Contains(displayName)) continue;
@@ -170,12 +194,20 @@ namespace SoundBar.Services
             }
 
             // Cleanup dead processes from cache
-            var cachedIds = _processCache.Keys.ToList();
+            List<int> cachedIds;
+            lock (_processCacheLock)
+            {
+                cachedIds = _processCache.Keys.ToList();
+            }
+
             foreach (var id in cachedIds)
             {
                 if (!seenProcessIdsThisTick.Contains(id))
                 {
-                    _processCache.Remove(id);
+                    lock (_processCacheLock)
+                    {
+                        _processCache.Remove(id);
+                    }
                 }
             }
 
@@ -191,6 +223,40 @@ namespace SoundBar.Services
             {
                 volumeControl.MasterVolume = level;
             });
+        }
+
+        private bool CheckIfBackgroundProcess(string rawProcessName)
+        {
+            string safeName = rawProcessName.Replace(".exe", "", StringComparison.OrdinalIgnoreCase);
+            var procs = System.Diagnostics.Process.GetProcessesByName(safeName);
+            bool isBackground = true;
+            try
+            {
+                foreach (var p in procs)
+                {
+                    try
+                    {
+                        if (p.MainWindowHandle != IntPtr.Zero)
+                        {
+                            isBackground = false;
+                        }
+                    }
+                    catch { } // Ignore access denied
+                }
+            }
+            finally
+            {
+                foreach (var p in procs) p.Dispose();
+            }
+            return isBackground;
+        }
+
+        public void ClearCache()
+        {
+            lock (_processCacheLock)
+            {
+                _processCache.Clear();
+            }
         }
 
         /// <summary>
@@ -380,8 +446,17 @@ namespace SoundBar.Services
                                 int processId = sessionControl.ProcessID;
                                 if (processId == 0) continue;
 
-                                if (_processCache.TryGetValue(processId, out var cached) &&
-                                    string.Equals(cached.RawProcessName, targetProcessName, StringComparison.OrdinalIgnoreCase))
+                                bool matchFound = false;
+                                lock (_processCacheLock)
+                                {
+                                    if (_processCache.TryGetValue(processId, out var cached) &&
+                                        string.Equals(cached.RawProcessName, targetProcessName, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        matchFound = true;
+                                    }
+                                }
+
+                                if (matchFound)
                                 {
                                     action(simpleVolume);
                                 }

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -623,6 +623,11 @@ namespace SoundBar.ViewModels
             }
         }
 
+        public void ForceRefreshAudioSessions()
+        {
+            _audioService.ClearCache();
+        }
+
         public void OpenBackgroundFolder()
         {
             try

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -220,6 +220,16 @@
                                    FontSize="14" 
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"/>
+
+                        <Button Click="RefreshApps_Click"
+                                Background="Transparent" 
+                                BorderBrush="Transparent"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                ToolTipService.ToolTip="Force refresh audio sessions"
+                                Padding="4">
+                            <FontIcon Glyph="&#xE72C;" FontSize="12"/>
+                        </Button>
                     </Grid>
                 </StackPanel>
 

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -363,6 +363,11 @@ namespace SoundBar.Views
             }
         }
 
+        private void RefreshApps_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.ForceRefreshAudioSessions();
+        }
+
         // Triggered when clicking the Hide button next to an app
         private void HideAppButton_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
### Description
This hotfix branch (v2.5.4) resolves a critical detection bug and a newly discovered multi-threading race condition. 

### Key Changes
* **Delayed-Window App Detection**: Applications like *Blue Prince* that connect to the audio subsystem slightly before opening a window were incorrectly cached as "background processes" indefinitely. `WindowsAudioMixerService` now automatically re-evaluates the window handle of background apps every 5 seconds to catch them when they finally render.
* **Thread-Safety Improvements**: Adding a manual refresh capability exposed a race condition where the UI thread and the background polling thread could concurrently modify `_processCache`, throwing an `InvalidOperationException`. All cache interactions are now heavily wrapped in a `lock (_processCacheLock)`.
* **Manual Refresh Fallback**: Added a manual `⟳` refresh icon next to the "Active Apps" text on the desktop UI to force a hard cache wipe.

### Testing Instructions
1. Run SoundBar.
2. Launch a game known to delay its window render (or any standard app) and ensure it pops up in the Active Apps list within 5 seconds.
3. Rapidly click the new Refresh button while apps are playing audio; ensure the app doesn't crash from collection modification exceptions.
