### PR TITLE
Fix/v3.1.1-io-device-layout-symmetry

### DIFF
--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v3.1.0";
+        public const string CurrentVersion = "v3.1.1";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -187,6 +187,7 @@
                     <Grid Margin="0,0,0,10">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition x:Name="OutputColumnDef" Width="*"/>
+                            <ColumnDefinition x:Name="MuteButtonColumnDef" Width="Auto"/>
                             <ColumnDefinition x:Name="InputColumnDef" Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
@@ -202,50 +203,42 @@
                                   BorderThickness="1"
                                   BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                  Margin="0,0,8,0"
+                                  Margin="0,0,6,0"
                                   Visibility="{x:Bind ViewModel.OutputDeviceVisibility, Mode=OneWay}"/>
 
-                        <!-- Input Device (Mic) Controls -->
-                        <Grid Grid.Column="1"
-                              Visibility="{x:Bind ViewModel.InputDeviceVisibility, Mode=OneWay}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            
-                            <!-- Mic Mute Toggle Button -->
-                            <Button x:Name="MicMuteButton"
-                                    Grid.Column="0"
-                                    Margin="0,0,6,0"
-                                    Width="36" Height="32"
-                                    Padding="0" MinWidth="0" MinHeight="0"
-                                    Background="{ThemeResource ControlFillColorDefaultBrush}"
-                                    BorderThickness="1"
-                                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                    CornerRadius="4"
-                                    Click="MicMuteButton_Click"
-                                    ToolTipService.ToolTip="Mute/Unmute Microphone">
-                                <TextBlock x:Name="MicMuteIcon"
-                                           Text="{x:Bind ViewModel.InputMuteIcon, Mode=OneWay}"
-                                           FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                           FontSize="14"/>
-                            </Button>
+                        <!-- Mic Mute Toggle Button -->
+                        <Button x:Name="MicMuteButton"
+                                Grid.Column="1"
+                                Margin="0,0,6,0"
+                                Width="36" Height="32"
+                                Padding="0" MinWidth="0" MinHeight="0"
+                                Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                BorderThickness="1"
+                                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                                CornerRadius="4"
+                                Click="MicMuteButton_Click"
+                                Visibility="{x:Bind ViewModel.InputDeviceVisibility, Mode=OneWay}"
+                                ToolTipService.ToolTip="Mute/Unmute Microphone">
+                            <TextBlock x:Name="MicMuteIcon"
+                                       Text="{x:Bind ViewModel.InputMuteIcon, Mode=OneWay}"
+                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                       FontSize="14"/>
+                        </Button>
 
-                            <!-- Input Device Picker -->
-                            <ComboBox x:Name="InputDeviceComboBox"
-                                      Grid.Column="1"
-                                      HorizontalAlignment="Stretch"
-                                      MinWidth="100"
-                                      MaxWidth="160"
-                                      ItemsSource="{Binding InputDevices}"
-                                      SelectedItem="{Binding SelectedInputDevice, Mode=TwoWay}"
-                                      DisplayMemberPath="Name"
-                                      PlaceholderText="Input..."
-                                      Background="{ThemeResource ControlFillColorDefaultBrush}"
-                                      BorderThickness="1"
-                                      BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                      Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
-                        </Grid>
+                        <!-- Input Device Picker -->
+                        <ComboBox x:Name="InputDeviceComboBox"
+                                  Grid.Column="2"
+                                  HorizontalAlignment="Stretch"
+                                  MinWidth="100"
+                                  ItemsSource="{Binding InputDevices}"
+                                  SelectedItem="{Binding SelectedInputDevice, Mode=TwoWay}"
+                                  DisplayMemberPath="Name"
+                                  PlaceholderText="Input..."
+                                  Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                  BorderThickness="1"
+                                  BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                                  Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                  Visibility="{x:Bind ViewModel.InputDeviceVisibility, Mode=OneWay}"/>
                     </Grid>
 
                     <!-- Master Volume -->

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -111,17 +111,33 @@ namespace SoundBar.Views
         {
             if (ViewModel == null) return;
 
-            if (ViewModel.ShowOutputDevice)
+            if (ViewModel.ShowOutputDevice && ViewModel.ShowInputDevice)
             {
                 OutputColumnDef.Width = new GridLength(1, GridUnitType.Star);
+                MuteButtonColumnDef.Width = GridLength.Auto;
+                InputColumnDef.Width = new GridLength(1, GridUnitType.Star);
+                DeviceComboBox.Margin = new Thickness(0, 0, 6, 0);
+                MicMuteButton.Margin = new Thickness(0, 0, 6, 0);
+            }
+            else if (ViewModel.ShowOutputDevice && !ViewModel.ShowInputDevice)
+            {
+                OutputColumnDef.Width = new GridLength(1, GridUnitType.Star);
+                MuteButtonColumnDef.Width = GridLength.Auto;
                 InputColumnDef.Width = GridLength.Auto;
-                InputDeviceComboBox.MaxWidth = 160;
+                DeviceComboBox.Margin = new Thickness(0);
+            }
+            else if (!ViewModel.ShowOutputDevice && ViewModel.ShowInputDevice)
+            {
+                OutputColumnDef.Width = GridLength.Auto;
+                MuteButtonColumnDef.Width = GridLength.Auto;
+                InputColumnDef.Width = new GridLength(1, GridUnitType.Star);
+                MicMuteButton.Margin = new Thickness(0, 0, 6, 0);
             }
             else
             {
                 OutputColumnDef.Width = GridLength.Auto;
-                InputColumnDef.Width = new GridLength(1, GridUnitType.Star);
-                InputDeviceComboBox.MaxWidth = double.PositiveInfinity;
+                MuteButtonColumnDef.Width = GridLength.Auto;
+                InputColumnDef.Width = GridLength.Auto;
             }
         }
 


### PR DESCRIPTION
Description:
This hotfix resolves a visual imbalance in the main UI introduced in v3.1.0 where the Input Device drop-down appeared shorter than the Output Device drop-down. 
Key Changes:
1. Flattened Grid Layout: The microphone mute button was previously nested inside the Input Device's half of the grid layout, causing it to push the input drop-down off-centre. It has been moved to its own dedicated centre column (`Auto` width).
2. Perfect Symmetry: Both the Output Device and Input Device drop-downs now sit in independent `1*` grid columns. This guarantees they always render at the exact same pixel width when both are visible.
3. Dynamic Margins: `UpdateIODeviceLayout()` has been updated to intelligently manage margins and column widths so the layout gracefully collapses to 100% width if the user hides one of the device strips via the Personalisation settings.
Testing:
- Verified 50/50 layout symmetry when resizing the application window.
- Verified smooth collapsing when toggling visibility of Output/Input device strips in Settings.