### PR TITLE
v3.1.2: UI Polish, Device Disconnect UX, and Memory Optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A sleek, customisable, and powerful audio mixer overlay for Windows, built natively with the Windows App SDK (WinUI 3). 
 
+**[Jump to: How to Install?](#how-to-install)**
+
 ## How it looks!
 <p align="center">
   <img width="30%" height="469" alt="image" src="https://github.com/user-attachments/assets/f109dd51-1771-4fb3-b68e-f0a8d6367e25" />
@@ -42,8 +44,16 @@ A sleek, customisable, and powerful audio mixer overlay for Windows, built nativ
 * **Automated Updates:** The app will periodically check GitHub for updates and notify you when a new release is available with a neat, 1-click update button.
 * **Modern WinUI 3 Design:** Built natively with the Windows App SDK for a sleek interface with smooth, responsive controls.
 
-## Download & Install (For Users)
-The application is built as a completely self-contained, portable `.exe`. You do not need to install anything or download the Windows App SDK runtime!
+## How to Install?
+
+### Option 1: Install via Winget (Recommended)
+You can easily install SoundBar using the Windows Package Manager (Winget). Open your command prompt or PowerShell and run:
+```powershell
+winget install levon2805.SoundBar
+```
+
+### Option 2: Portable Download
+The application is also built as a completely self-contained, portable `.exe`. You do not need to install anything or download the Windows App SDK runtime!
 
 1. Go to the [Releases](../../releases) tab on the right side of this GitHub repository.
 2. Download the latest `SoundBar.zip` file.
@@ -53,7 +63,7 @@ The application is built as a completely self-contained, portable `.exe`. You do
 > **Note on Windows SmartScreen:** Because this is a new open-source application, Windows may show a "Windows protected your PC" warning when you first run the app. This is completely normal for new independent software. To run the app, simply click **"More info"** and then **"Run anyway"**.
 
 ## Development Setup
-This project uses a modern multi-project enterprise structure:
+Structure:
 * `src/SoundBar/` contains the main WinUI 3 application.
 * `tests/SoundBar.Tests/` contains the xUnit automated tests.
 * `ReleaseTools/` contains internal deployment utilities.

--- a/src/SoundBar/Services/UpdateService.cs
+++ b/src/SoundBar/Services/UpdateService.cs
@@ -21,7 +21,7 @@ namespace SoundBar.Services
         /// <summary>
         /// The version of the app currently running. Remember to bump this before every release!
         /// </summary>
-        public const string CurrentVersion = "v3.1.1";
+        public const string CurrentVersion = "v3.1.2";
         
         /// <summary>
         /// Our public key for verifying updates. This stops cheeky bad actors from hijacking the update process.

--- a/src/SoundBar/ViewModels/MainViewModel.cs
+++ b/src/SoundBar/ViewModels/MainViewModel.cs
@@ -46,9 +46,15 @@ namespace SoundBar.ViewModels
         /// </summary>
         public ObservableCollection<AudioAppModel> Apps { get; set; }
 
-        // Saved presets
-        public ObservableCollection<AudioPreset> Presets { get; }
-        public ObservableCollection<AudioDeviceModel> AudioDevices { get; }
+        /// <summary>
+        /// A collection of the user's saved audio presets.
+        /// </summary>
+        public ObservableCollection<AudioPreset> Presets { get; private set; }
+        
+        /// <summary>
+        /// The list of audio output devices currently detected by the system.
+        /// </summary>
+        public ObservableCollection<AudioDeviceModel> AudioDevices { get; private set; }
 
         private AudioDeviceModel? _selectedAudioDevice;
         public AudioDeviceModel? SelectedAudioDevice
@@ -316,7 +322,7 @@ namespace SoundBar.ViewModels
                 () => SelectedAudioDevice,
                 (deviceId) =>
                 {
-                    _dispatcherQueue.TryEnqueue(() =>
+                    RunOnUIThread(() =>
                     {
                         var device = AudioDevices.FirstOrDefault(d => d.Id == deviceId);
                         if (device != null)
@@ -329,7 +335,7 @@ namespace SoundBar.ViewModels
                 () => SelectedInputDevice,
                 (deviceId) =>
                 {
-                    _dispatcherQueue.TryEnqueue(() =>
+                    RunOnUIThread(() =>
                     {
                         var device = InputDevices.FirstOrDefault(d => d.Id == deviceId);
                         if (device != null)
@@ -343,7 +349,7 @@ namespace SoundBar.ViewModels
 
             _companionServer.StateChanged += () =>
             {
-                _dispatcherQueue.TryEnqueue(() =>
+                RunOnUIThread(() =>
                 {
                     OnPropertyChanged(nameof(IsCompanionServerRunning));
                     OnPropertyChanged(nameof(CompanionServerUrl));
@@ -422,6 +428,9 @@ namespace SoundBar.ViewModels
 
         // --- Input Device (Microphone) Properties ---
 
+        /// <summary>
+        /// The list of audio input devices (like microphones) currently detected by the system.
+        /// </summary>
         public ObservableCollection<AudioDeviceModel> InputDevices { get; } = new();
 
         private AudioDeviceModel? _selectedInputDevice;
@@ -474,8 +483,6 @@ namespace SoundBar.ViewModels
 
         private void UpdateInputDevices(List<AudioDeviceModel> inputDevices)
         {
-            if (inputDevices.Count == 0 && InputDevices.Count == 0) return;
-
             // Only rebuild if the device list actually changed
             var currentIds = InputDevices.Select(d => d.Id).ToList();
             var newIds = inputDevices.Select(d => d.Id).ToList();
@@ -497,6 +504,13 @@ namespace SoundBar.ViewModels
             {
                 _isUpdatingInputDeviceFromSystem = true;
                 SelectedInputDevice = InputDevices.FirstOrDefault(d => d.Id == defaultDevice.Id);
+                _isUpdatingInputDeviceFromSystem = false;
+            }
+            else if (inputDevices.Count == 0 && _selectedInputDevice != null)
+            {
+                // No devices available — clear selection so placeholder text is shown
+                _isUpdatingInputDeviceFromSystem = true;
+                SelectedInputDevice = null;
                 _isUpdatingInputDeviceFromSystem = false;
             }
         }
@@ -688,21 +702,37 @@ namespace SoundBar.ViewModels
         }
 
         // Dispatcher to safely update UI from background threads
-        private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue;
+        private readonly Microsoft.UI.Dispatching.DispatcherQueue? _dispatcherQueue;
 
-        // Constructor
-        public MainViewModel(SettingsService settingsService)
+        // Constructor for DI / Testing
+        internal MainViewModel(SettingsService settingsService, IAudioMixerService audioService, UpdateService updateService = null, MediaInfoService mediaInfoService = null, HotkeyService hotkeyService = null)
         {
             _settingsService = settingsService;
-            _updateService = new UpdateService();
-            _mediaInfoService = new MediaInfoService();
-            _hotkeyService = new HotkeyService();
+            _updateService = updateService ?? new UpdateService();
+            _mediaInfoService = mediaInfoService ?? new MediaInfoService();
+            _hotkeyService = hotkeyService ?? new HotkeyService();
             _hotkeyService.KeyPressed += HotkeyService_KeyPressed;
-            _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            try { _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread(); } catch { _dispatcherQueue = null; }
+            _audioService = audioService;
 
-            // Connect to audio service
-            _audioService = new WindowsAudioMixerService();
+            InitializeInternal();
+        }
 
+        private void RunOnUIThread(Microsoft.UI.Dispatching.DispatcherQueueHandler action)
+        {
+            if (_dispatcherQueue != null)
+                _dispatcherQueue.TryEnqueue(action);
+            else
+                action();
+        }
+
+        // Default Constructor
+        public MainViewModel(SettingsService settingsService) : this(settingsService, new WindowsAudioMixerService())
+        {
+        }
+
+        private void InitializeInternal()
+        {
             // Setup data container
             Apps = new ObservableCollection<AudioAppModel>();
             HiddenApps = new ObservableCollection<string>(_settingsService.Settings.HiddenApps);
@@ -711,9 +741,13 @@ namespace SoundBar.ViewModels
             Presets = new ObservableCollection<AudioPreset>(_settingsService.Settings.Presets);
             AudioDevices = new ObservableCollection<AudioDeviceModel>();
 
-            _progressTimer = new DispatcherTimer();
-            _progressTimer.Interval = TimeSpan.FromMilliseconds(500);
-            _progressTimer.Tick += ProgressTimer_Tick;
+            try 
+            {
+                _progressTimer = new DispatcherTimer();
+                _progressTimer.Interval = TimeSpan.FromMilliseconds(500);
+                _progressTimer.Tick += ProgressTimer_Tick;
+            }
+            catch { }
 
             _mediaInfoService.MediaInfoChanged += MediaInfoService_MediaInfoChanged;
             _mediaInfoService.TimelineInfoChanged += MediaInfoService_TimelineInfoChanged;
@@ -744,7 +778,7 @@ namespace SoundBar.ViewModels
 
         private void HotkeyService_KeyPressed(object? sender, HotkeyEventArgs e)
         {
-            _dispatcherQueue.TryEnqueue(() =>
+            RunOnUIThread(() =>
             {
                 string pressedString = ParseHotkeyToString(e.Key, e.Modifiers);
 
@@ -886,7 +920,7 @@ namespace SoundBar.ViewModels
             bool hasUpdate = await _updateService.CheckForUpdatesAsync();
             if (hasUpdate)
             {
-                _dispatcherQueue.TryEnqueue(() =>
+                RunOnUIThread(() =>
                 {
                     LatestVersion = _updateService.LatestVersion;
                     UpdateAvailable = true;
@@ -913,7 +947,7 @@ namespace SoundBar.ViewModels
                 if (!System.IO.Directory.Exists(folder))
                 {
                     System.IO.Directory.CreateDirectory(folder);
-                    _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+                    RunOnUIThread(() => BackgroundImage = null);
                     return; 
                 }
 
@@ -931,7 +965,7 @@ namespace SoundBar.ViewModels
 
                 if (imagePath != null)
                 {
-                    _dispatcherQueue.TryEnqueue(async () =>
+                    RunOnUIThread(async () =>
                     {
                         try
                         {
@@ -957,12 +991,12 @@ namespace SoundBar.ViewModels
                 }
                 else
                 {
-                    _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+                    RunOnUIThread(() => BackgroundImage = null);
                 }
             }
             catch
             {
-                _dispatcherQueue.TryEnqueue(() => BackgroundImage = null);
+                RunOnUIThread(() => BackgroundImage = null);
             }
         }
 
@@ -1045,7 +1079,7 @@ namespace SoundBar.ViewModels
                         catch { }
 
                         // Update UI thread safely
-                        _dispatcherQueue.TryEnqueue(() =>
+                        RunOnUIThread(() =>
                         {
                             UpdateCollection(sessions);
 
@@ -1164,7 +1198,7 @@ namespace SoundBar.ViewModels
                 if (app != null)
                 {
                     // Execute on the next UI tick so the TextBox has finished its TwoWay update
-                    _dispatcherQueue.TryEnqueue(() =>
+                    RunOnUIThread(() =>
                     {
                         app.AliasChanged -= HandleAliasChanged; // Temporarily unsubscribe to prevent loop
                         app.Name = app.DisplayName;
@@ -1537,7 +1571,7 @@ namespace SoundBar.ViewModels
         public Microsoft.UI.Xaml.Visibility FallbackIconVisibility => CurrentSongThumbnail == null ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed;
 
         // --- Timeline & Scrubbing ---
-        private DispatcherTimer _progressTimer;
+        private DispatcherTimer? _progressTimer;
         private TimeSpan _basePosition;
         private DateTimeOffset _lastUpdatedTime;
         private bool _isPlaying;
@@ -1603,7 +1637,7 @@ namespace SoundBar.ViewModels
 
         private void MediaInfoService_TimelineInfoChanged(object? sender, TimelineInfoEventArgs e)
         {
-            _dispatcherQueue.TryEnqueue(() =>
+            RunOnUIThread(() =>
             {
                 _basePosition = e.Position;
                 _lastUpdatedTime = e.LastUpdatedTime;
@@ -1616,10 +1650,10 @@ namespace SoundBar.ViewModels
                     CurrentSongPositionSeconds = e.Position.TotalSeconds;
                 }
 
-                if (_isPlaying && !_progressTimer.IsEnabled)
-                    _progressTimer.Start();
-                else if (!_isPlaying && _progressTimer.IsEnabled)
-                    _progressTimer.Stop();
+                if (_isPlaying && (_progressTimer?.IsEnabled == false))
+                    _progressTimer?.Start();
+                else if (!_isPlaying && (_progressTimer?.IsEnabled == true))
+                    _progressTimer?.Stop();
             });
         }
 
@@ -1648,7 +1682,7 @@ namespace SoundBar.ViewModels
 
         private void MediaInfoService_MediaInfoChanged(object? sender, MediaInfoEventArgs e)
         {
-            _dispatcherQueue.TryEnqueue(async () =>
+            RunOnUIThread(async () =>
             {
                 CurrentSongTitle = string.IsNullOrEmpty(e.Title) ? "Not Playing" : e.Title;
                 CurrentSongArtist = e.Artist;
@@ -1721,6 +1755,11 @@ namespace SoundBar.ViewModels
                 if (newDefault != null && (SelectedAudioDevice == null || SelectedAudioDevice.Id != newDefault.Id))
                 {
                     SelectedAudioDevice = newDefault;
+                }
+                else if (latestDevices.Count == 0 && SelectedAudioDevice != null)
+                {
+                    // No devices available — clear selection so placeholder text is shown
+                    SelectedAudioDevice = null;
                 }
                 _isUpdatingDeviceFromSystem = false;
             }
@@ -1821,6 +1860,11 @@ namespace SoundBar.ViewModels
             if (_audioService is IDisposable disposable)
             {
                 disposable.Dispose();
+            }
+
+            if (_updateService is IDisposable updateDisposable)
+            {
+                updateDisposable.Dispose();
             }
         }
     }

--- a/src/SoundBar/Views/MainWindow.xaml
+++ b/src/SoundBar/Views/MainWindow.xaml
@@ -198,7 +198,7 @@
                                   ItemsSource="{Binding AudioDevices}"
                                   SelectedItem="{Binding SelectedAudioDevice, Mode=TwoWay}"
                                   DisplayMemberPath="Name"
-                                  PlaceholderText="&#xE767;  Output Device..."
+                                  PlaceholderText="No output devices detected"
                                   Background="{ThemeResource ControlFillColorDefaultBrush}"
                                   BorderThickness="1"
                                   BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
@@ -233,7 +233,7 @@
                                   ItemsSource="{Binding InputDevices}"
                                   SelectedItem="{Binding SelectedInputDevice, Mode=TwoWay}"
                                   DisplayMemberPath="Name"
-                                  PlaceholderText="Input..."
+                                  PlaceholderText="No input devices detected"
                                   Background="{ThemeResource ControlFillColorDefaultBrush}"
                                   BorderThickness="1"
                                   BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
@@ -270,7 +270,7 @@
                         </Grid>
                     </StackPanel>
 
-                    <Border Height="1" Background="#555555" Margin="0,20,0,10"/>
+                    <Border Height="1" Background="{ThemeResource ControlStrokeColorDefaultBrush}" Margin="0,20,0,10"/>
 
                     <!-- Active Apps Header + List -->
                     <StackPanel Visibility="{x:Bind ViewModel.ActiveAppsVisibility, Mode=OneWay}">
@@ -373,7 +373,7 @@
                                 </Image>
                             </Border>
                             <!-- Fallback Icon behind image -->
-                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE189;" FontSize="64" Foreground="#444444" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.FallbackIconVisibility, Mode=OneWay}" />
+                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Text="&#xE189;" FontSize="64" Foreground="{ThemeResource TextFillColorTertiaryBrush}" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.FallbackIconVisibility, Mode=OneWay}" />
                         </Grid>
                     </Viewbox>
 
@@ -486,7 +486,7 @@
 
                 <!-- Media Controls -->
                 <StackPanel Grid.Row="2" Margin="0,10,0,-10" Visibility="{x:Bind ViewModel.MediaControlsVisibility, Mode=OneWay}">
-                    <Border Height="1" Background="#555555" Margin="0,0,0,8"/>
+                    <Border Height="1" Background="{ThemeResource ControlStrokeColorDefaultBrush}" Margin="0,0,0,8"/>
                     
                     <Grid>
                         <!-- Music Player Mode Toggle -->

--- a/src/SoundBar/Views/MainWindow.xaml.cs
+++ b/src/SoundBar/Views/MainWindow.xaml.cs
@@ -195,9 +195,14 @@ namespace SoundBar.Views
             // Sync Mic Mute icon colour
             if (MicMuteIcon != null)
             {
-                MicMuteIcon.Foreground = ViewModel.IsInputMuted
-                    ? new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 80, 80))  // Red when muted
-                    : new SolidColorBrush(Microsoft.UI.Colors.White);                    // Normal when live
+                if (ViewModel.IsInputMuted)
+                {
+                    MicMuteIcon.Foreground = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 80, 80)); // Red when muted
+                }
+                else
+                {
+                    MicMuteIcon.ClearValue(TextBlock.ForegroundProperty); // Fall back to theme
+                }
             }
 
             // Lazily find the ItemsControl because XAML bindings might not be evaluated immediately in the constructor
@@ -311,7 +316,7 @@ namespace SoundBar.Views
             TitleBarGrid.PointerReleased += TitleBarGrid_PointerReleased;
             TitleBarGrid.PointerCanceled += TitleBarGrid_PointerCanceled;
 
-            this.Closed += (s, e) => { ViewModel.Dispose(); };
+            this.Closed += (s, e) => { _focusOutlineTimer?.Stop(); ViewModel.Dispose(); };
 
             SongPositionSlider.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(SongPositionSlider_PointerPressed), true);
 
@@ -750,7 +755,7 @@ namespace SoundBar.Views
                 var dndToggle = new ToggleSwitch { OnContent = "Enabled", OffContent = "Disabled" };
                 dndToggle.SetBinding(ToggleSwitch.IsOnProperty, new Microsoft.UI.Xaml.Data.Binding { Path = new PropertyPath("IsDoNotDisturbEnabled"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
                 
-                // Keep the icon color logic synced if they toggle from settings menu
+                // Keep the icon colour logic synced if they toggle from settings menu
                 dndToggle.Toggled += DndToggleButton_Changed;
                 
                 dndStack.Children.Add(dndToggle);

--- a/tests/SoundBar.Tests/MainViewModelTests.cs
+++ b/tests/SoundBar.Tests/MainViewModelTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using SoundBar.Models;
+using SoundBar.Services;
+using SoundBar.ViewModels;
+using Xunit;
+
+namespace SoundBar.Tests
+{
+    public class MainViewModelTests
+    {
+        [Fact]
+        public async Task PollSystemAudioState_WhenDevicesDisconnected_ClearsSelectedDevices()
+        {
+            // Arrange
+            var mockAudioService = new Mock<IAudioMixerService>();
+            
+            // We can pass null or mocks for these if we don't strictly need them to be mocked for this test,
+            // but let's mock what we can or just use the concrete SettingsService if needed.
+            // Wait, MainViewModel internal constructor expects:
+            // SettingsService settingsService, IAudioMixerService audioService, UpdateService updateService = null, MediaInfoService mediaInfoService = null, HotkeyService hotkeyService = null
+            
+            // We need a real SettingsService or a mocked wrapper, but SettingsService doesn't have an interface.
+            // Since it takes a filepath, we can just pass a dummy one.
+            var dummySettings = new SettingsService("dummy_path.json");
+
+            var initialOutputDevices = new List<AudioDeviceModel>
+            {
+                new AudioDeviceModel { Id = "out1", Name = "Speakers", IsDefault = true }
+            };
+            var initialInputDevices = new List<AudioDeviceModel>
+            {
+                new AudioDeviceModel { Id = "in1", Name = "Microphone", IsDefault = true }
+            };
+
+            // Setup audio service to return our mock devices initially
+            mockAudioService.Setup(s => s.GetAudioDevices()).Returns(initialOutputDevices);
+            mockAudioService.Setup(s => s.GetInputDevices()).Returns(initialInputDevices);
+            mockAudioService.Setup(s => s.GetActiveAudioSessions()).Returns(new List<AudioSessionData>());
+
+            var viewModel = new MainViewModel(
+                dummySettings,
+                mockAudioService.Object);
+
+            // Give the polling loop a moment to pick up the initial devices
+            await Task.Delay(500); 
+
+            // Assert initial state: devices are selected
+            Assert.NotNull(viewModel.SelectedAudioDevice);
+            Assert.Equal("out1", viewModel.SelectedAudioDevice?.Id);
+            Assert.NotNull(viewModel.SelectedInputDevice);
+            Assert.Equal("in1", viewModel.SelectedInputDevice?.Id);
+
+            // Act: Simulate user unplugging devices (empty lists returned)
+            mockAudioService.Setup(s => s.GetAudioDevices()).Returns(new List<AudioDeviceModel>());
+            mockAudioService.Setup(s => s.GetInputDevices()).Returns(new List<AudioDeviceModel>());
+
+            // Wait for the next poll cycle to pick up the empty lists
+            await Task.Delay(500);
+
+            // Assert final state: selections are cleared to show placeholder text
+            Assert.Null(viewModel.SelectedAudioDevice);
+            Assert.Null(viewModel.SelectedInputDevice);
+
+            viewModel.Dispose();
+        }
+    }
+}

--- a/tests/SoundBar.Tests/SettingsServiceTests.cs
+++ b/tests/SoundBar.Tests/SettingsServiceTests.cs
@@ -172,6 +172,7 @@ namespace SoundBar.Tests
             service1.Settings.ShowInputDevice = false;
             service1.Settings.ShowMasterVolume = false;
             service1.Settings.ShowActiveApps = false;
+            service1.Settings.InputMuteHotkey = "Control+Shift+M";
 
             // Act
             service1.SaveSettings();
@@ -182,6 +183,7 @@ namespace SoundBar.Tests
             Assert.False(service2.Settings.ShowInputDevice);
             Assert.False(service2.Settings.ShowMasterVolume);
             Assert.False(service2.Settings.ShowActiveApps);
+            Assert.Equal("Control+Shift+M", service2.Settings.InputMuteHotkey);
         }
 
         [Fact]


### PR DESCRIPTION
## Overview
This hotfix introduces a series of UI polish improvements, user experience enhancements for disconnected devices, and backend resource fixes.

### Changes Made:
* **Theme Consistency**: Fixed multiple instances of hardcoded colours in XAML/C# that broke when switching between Light and Dark mode (including the Microphone Mute icon, fallback music cover icon, and UI separators). They now correctly use WinUI 3 `ThemeResource` bindings.
* **Device Disconnect UX**: When the system detects that all audio input or output devices have been unplugged, the UI now gracefully clears the selection and displays helpful placeholder messages ("No input/output devices detected") instead of remaining blank.
* **Memory & Resource Fixes**:
  * Fixed a background leak where the `_focusOutlineTimer` was not stopped when the window was closed.
  * Correctly disposed of `UpdateService` to free its `HttpClient` on application exit.
* **Test Hardening**: Updated `MainViewModel` to gracefully handle headless execution for unit testing, catching and bypassing `DispatcherQueue` and `DispatcherTimer` initialization exceptions.
* **Documentation**: Added Winget installation instructions and a quick-access "How to Install?" jump link to the README.

### Testing:
* Added `SettingsServiceTests` to ensure `InputMuteHotkey` saves/loads properly.
* Added `MainViewModelTests` to verify device clearing logic.
* Verified idempotent disposal for `AudioAppModel`.
